### PR TITLE
refactor: replace `dedent_triple_quote_string` with `promptify`

### DIFF
--- a/src/brag/agents.py
+++ b/src/brag/agents.py
@@ -7,7 +7,7 @@ from typing import TypeVar
 from pydantic_ai import Agent
 from pydantic_ai.models import KnownModelName
 
-from brag.text_formatters import dedent_triple_quote_string
+from brag.text_formatters import promptify
 
 _T = TypeVar("_T")
 
@@ -119,7 +119,7 @@ def _generate_initial_brag_document_prompt(chunk: str) -> str:
         A string containing the prompt for generating the initial brag document.
 
     """
-    return dedent_triple_quote_string(
+    return promptify(
         """
             Generate a brag document from the following context:
             <context>
@@ -174,7 +174,7 @@ def _generate_update_brag_document_prompt(
         A string containing the prompt for refining the brag document.
 
     """
-    return dedent_triple_quote_string(
+    return promptify(
         """
             Produce a refined brag document.
 
@@ -201,7 +201,7 @@ def _build_agent_from_system_prompt(
     return Agent(
         model_name,
         model_settings={"temperature": 0.0},
-        system_prompt=dedent_triple_quote_string(system_prompt),
+        system_prompt=promptify(system_prompt),
     )
 
 

--- a/src/brag/text_formatters.py
+++ b/src/brag/text_formatters.py
@@ -3,7 +3,15 @@
 import textwrap
 
 
-def dedent_triple_quote_string(text: str | None) -> str:
+def promptify(*blocks: str | None, joiner: str = "\n\n") -> str:
+    """Compose a text from multiple building blocks.
+
+    All building blocks get formatted in advance to ensure that the result text has consistent indentation.
+    """
+    return joiner.join(_dedent_triple_quote_string(block) for block in blocks if block)
+
+
+def _dedent_triple_quote_string(text: str | None) -> str:
     """Dedent a triple quote string.
 
     This allows us to write multi-line strings with consistent indentation:
@@ -22,11 +30,3 @@ def dedent_triple_quote_string(text: str | None) -> str:
     if not text:
         return ""
     return textwrap.dedent(text).strip()
-
-
-def compose_text(*blocks: str | None, joiner: str = "\n\n") -> str:
-    """Compose a text from multiple building blocks.
-
-    All building blocks get formatted in advance to ensure that the result text has consistent indentation.
-    """
-    return joiner.join(dedent_triple_quote_string(block) for block in blocks if block)

--- a/tests/brag/test_text_formatters.py
+++ b/tests/brag/test_text_formatters.py
@@ -1,6 +1,6 @@
 import pytest
 
-from brag.text_formatters import compose_text, dedent_triple_quote_string
+from brag.text_formatters import _dedent_triple_quote_string, promptify
 
 
 @pytest.mark.parametrize(
@@ -39,7 +39,7 @@ def test_dedent_triple_quote_string(
     expected: str,
 ) -> None:
     """Test dedent_triple_quote_string."""
-    assert dedent_triple_quote_string(text) == expected
+    assert _dedent_triple_quote_string(text) == expected
 
 
 @pytest.mark.parametrize(
@@ -85,15 +85,15 @@ def test_dedent_triple_quote_string(
         ),
     ),
 )
-def test_compose_text(
+def test_promptify(
     blocks: tuple[str | None, ...],
     expected: str,
 ) -> None:
     """Test compose_text with no blocks."""
-    assert compose_text(*blocks) == expected
+    assert promptify(*blocks) == expected
 
 
-def test_compose_text_custom_joiner() -> None:
+def test_promptify_custom_joiner() -> None:
     """Test compose_text with a custom joiner."""
     block1 = """
         Hello, world!
@@ -102,4 +102,4 @@ def test_compose_text_custom_joiner() -> None:
         Goodbye, world!
         """
     expected = "Hello, world!\n---\nGoodbye, world!"
-    assert compose_text(block1, block2, joiner="\n---\n") == expected
+    assert promptify(block1, block2, joiner="\n---\n") == expected


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Replaces the `dedent_triple_quote_string` function with a more general `promptify` function to handle the composition of text blocks with consistent indentation.