### PR TITLE
build: set the project version in `src/brag/__init__.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
+dynamic = ["version"]
+
 name = "brag"
-version = "0.1.0"
 description = "Generate and maintain a brag document automatically from your GitHub contributions, powered by AI."
 
 authors = [{ name = "Ruan Comelli", email = "ruancomelli@gmail.com" }]
@@ -24,6 +25,9 @@ brag = "brag.__main__:app"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "src/brag/__init__.py"
 
 [dependency-groups]
 dev = [

--- a/src/brag/__init__.py
+++ b/src/brag/__init__.py
@@ -1,1 +1,3 @@
 """Generate and maintain a brag document automatically from your GitHub contributions, powered by AI."""
+
+__version__ = "0.1.0"


### PR DESCRIPTION
## Summary by Sourcery

Configures the project to dynamically set the version from `src/brag/__init__.py` during the build process.

Build:
- Configures the project to dynamically set the version from `src/brag/__init__.py` during the build process.
- Updates `pyproject.toml` to use hatchling's dynamic versioning feature, pointing to the `__version__` variable in `src/brag/__init__.py`.