### PR TITLE
ci: add bash scripts for simplifying common tasks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,11 +15,11 @@ jobs:
       matrix:
         check:
         - name: lint
-          run: uv run --group ci nox --session lint
+          run: bash scripts/lint.sh
         - name: format
-          run: uv run --group ci nox --session format
-        - name: typecheck
-          run: uv run --group ci nox --session type-check
+          run: bash scripts/format.sh
+        - name: type-check
+          run: bash scripts/type-check.sh
 
     name: Python ${{ matrix.check.name }}
     runs-on: ubuntu-latest
@@ -60,4 +60,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Run tests
-      run: uv run --group ci nox --session test-cov
+      run: bash scripts/test.sh
+
+    - name: Run tests with coverage
+      run: bash scripts/test-cov.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,19 +37,19 @@ repos:
     name: Lint Python code and fix violations
     stages: [pre-commit, pre-push]
     language: system
-    entry: uv run --group ci nox --session lint --
+    entry: bash scripts/lint.sh
     types: [python]
 
   - id: format
     name: Format Python code
     stages: [pre-commit, pre-push]
     language: system
-    entry: uv run --group ci nox --session format --
+    entry: bash scripts/format.sh
     types: [python]
 
-  - id: typecheck
+  - id: type-check
     name: Type check Python code
     stages: [pre-commit, pre-push]
     language: system
-    entry: uv run --group ci nox --session type-check --
+    entry: bash scripts/type-check.sh
     types: [python]

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,26 +9,6 @@ PYTHON_VERSIONS = nox.project.python_versions(PYPROJECT)
 
 
 @nox.session(
-    default=False,
-    venv_backend="uv",
-    reuse_venv=True,
-)
-def dev(session: nox.Session) -> None:
-    """Set up a python development environment for the project."""
-    session.run_install(
-        "uv",
-        "sync",
-        "--all-groups",
-        env={"VIRTUAL_ENV": ""},
-    )
-    session.run(
-        "pre-commit",
-        "install",
-        external=True,
-    )
-
-
-@nox.session(
     venv_backend="uv",
     reuse_venv=True,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ enable_error_code = "possibly-undefined"
 
 [[tool.mypy.overrides]]
 module = ["nox"]
-follow_untyped_imports = true
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 xfail_strict = true

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+
 uv run --group ci nox --session format -- $@

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,1 @@
+uv run --group ci nox --session format -- $@

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,2 +1,4 @@
+#!/bin/bash
+
 uv sync --all-groups
 uv run --group pre-commit pre-commit install

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,2 @@
+uv sync --all-groups
+uv run --group pre-commit pre-commit install

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+
 uv run --group ci nox --session lint -- $@

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,1 @@
+uv run --group ci nox --session lint -- $@

--- a/scripts/test-cov.sh
+++ b/scripts/test-cov.sh
@@ -1,0 +1,1 @@
+uv run --group ci nox --session test-cov -- $@

--- a/scripts/test-cov.sh
+++ b/scripts/test-cov.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+
 uv run --group ci nox --session test-cov -- $@

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+
 uv run --group ci nox --session test -- $@

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,1 @@
+uv run --group ci nox --session test -- $@

--- a/scripts/type-check.sh
+++ b/scripts/type-check.sh
@@ -1,0 +1,1 @@
+uv run --group ci nox --session type-check -- $@

--- a/scripts/type-check.sh
+++ b/scripts/type-check.sh
@@ -1,1 +1,3 @@
+#!/bin/bash
+
 uv run --group ci nox --session type-check -- $@


### PR DESCRIPTION
ci: add bash scripts for simplifying common tasks

refactor: replace `nox --session dev` with an `init.sh` script

## Summary by Sourcery

Introduce bash scripts to simplify common CI tasks and improve maintainability. This change replaces direct `nox` commands in CI workflows and pre-commit hooks with calls to dedicated bash scripts, and also replaces the `nox --session dev` command with an `init.sh` script.

CI:
- Introduce bash scripts to simplify common CI tasks such as linting, formatting, type checking, and running tests.
- Replace the `nox --session dev` command with an `init.sh` script for setting up the development environment.