### PR TITLE
ci: add ShellCheck to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,3 +66,11 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,10 @@ repos:
   rev: v0.6.1
   hooks:
   - id: pre-commit-update
-
+- repo: https://github.com/koalaman/shellcheck-precommit
+  rev: v0.10.0
+  hooks:
+  - id: shellcheck
 - repo: local
   hooks:
   - id: lint

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-uv run --group format ruff format $@
+uv run --group format ruff format "$@"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-uv run --group lint ruff check --fix $@
+uv run --group lint ruff check --fix "$@"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-uv run --group test pytest $@
+uv run --group test pytest "$@"

--- a/scripts/type-check.sh
+++ b/scripts/type-check.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-uv run --group type-check mypy $@
+uv run --group type-check mypy "$@"


### PR DESCRIPTION
## Summary by Sourcery

Add ShellCheck to CI to lint shell scripts.

CI:
- Integrate ShellCheck into the CI workflow to automatically lint shell scripts.
- Add a pre-commit hook for ShellCheck to lint shell scripts before committing.