### PR TITLE
ci: add ActionLint to CI

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,12 @@
+name: Lint GitHub Actions workflows
+on: [push, pull_request]
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Check workflow files
+      uses: docker://rhysd/actionlint:latest
+      with:
+        args: -color

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 repos:
+
 - repo: https://github.com/astral-sh/uv-pre-commit
   rev: 0.6.4
   hooks:
@@ -7,6 +8,7 @@ repos:
         # Install all packages
   - id: uv-sync
     args: [--locked, --all-packages]
+
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
   hooks:
@@ -21,19 +23,28 @@ repos:
   - id: pretty-format-json
     args: [--autofix, --indent, '2']
   - id: trailing-whitespace
+
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
   rev: v2.14.0
   hooks:
   - id: pretty-format-yaml
     args: [--autofix, --indent, '2']
+
 - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
   rev: v0.6.1
   hooks:
   - id: pre-commit-update
+
 - repo: https://github.com/koalaman/shellcheck-precommit
   rev: v0.10.0
   hooks:
   - id: shellcheck
+
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.7.7
+  hooks:
+  - id: actionlint
+
 - repo: local
   hooks:
   - id: lint


### PR DESCRIPTION
## Summary by Sourcery

Add ActionLint to CI to lint GitHub Actions workflows.

CI:
- Integrate ActionLint into the CI workflow to automatically check workflow files for errors.
- Add a new workflow file for ActionLint.