### PR TITLE
ci: add zizmor to CI

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,36 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ['**']
+
+jobs:
+  zizmor:
+    name: zizmor latest via PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      # required for workflows in private repositories
+      contents: read
+      actions: read
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Install the latest version of uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Run zizmor 🌈
+      run: uvx zizmor --format sarif . > results.sarif
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Upload SARIF file
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: results.sarif
+        category: zizmor

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,11 @@ repos:
   hooks:
   - id: actionlint
 
+- repo: https://github.com/woodruffw/zizmor-pre-commit
+  rev: v1.4.1
+  hooks:
+  - id: zizmor
+
 - repo: local
   hooks:
   - id: lint


### PR DESCRIPTION
## Summary by Sourcery

Adds zizmor to CI to perform security analysis.

CI:
- Adds a new workflow to run zizmor, a security analysis tool, on push and pull requests.
- Configures the workflow to upload SARIF files for use with GitHub code scanning.