### PR TITLE
docs: publish docs to GitHub pages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,54 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Build documentation
+      run: bash scripts/docs-build.sh
+
+    - name: Upload documentation artifacts
+      if: github.event_name != 'pull_request'
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: ./site
+
+  deploy:
+    name: Deploy Documentation
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+
+    needs: build
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,221 @@
+# API Reference
+
+This guide provides details about the key modules and functions in the Brag AI codebase. It's useful if you want to use Brag AI programmatically or extend its functionality.
+
+## Core Modules
+
+### `brag.__main__`
+
+The entry point for the Brag AI CLI application.
+
+```python
+from brag.__main__ import app
+
+# Run the CLI app
+app()
+```
+
+### `brag.cli`
+
+Contains the command-line interface implementation using Typer.
+
+```python
+from brag.cli import app
+
+# Access the Typer app
+app.info
+```
+
+### `brag.github_commits`
+
+Provides functionality for retrieving commits from GitHub repositories.
+
+```python
+from brag.github_commits import get_commits_for_user
+
+# Get commits for a user in a repository
+commits = get_commits_for_user(
+    repo_name="owner/repo",
+    username="github-username",
+    token="github-api-token",
+    from_date="2023-01-01",
+    to_date="2023-12-31",
+    limit=50
+)
+```
+
+### `brag.agents`
+
+Contains AI agent implementations for generating brag documents.
+
+```python
+from brag.agents import BragDocumentGenerator
+
+# Create a brag document generator
+generator = BragDocumentGenerator(
+    model="openai:gpt-4o",
+    language="English"
+)
+
+# Generate a brag document from commits
+brag_document = generator.generate_brag_document(commits)
+```
+
+### `brag.repository`
+
+Provides abstractions for working with Git repositories.
+
+```python
+from brag.repository import Repository
+
+# Create a repository instance
+repo = Repository.from_name("owner/repo", token="github-api-token")
+```
+
+### `brag.text_formatters`
+
+Contains utilities for formatting text output.
+
+```python
+from brag.text_formatters import markdown_formatter
+
+# Format text as markdown
+formatted_text = markdown_formatter("# Heading\n\nParagraph")
+```
+
+## Key Classes and Functions
+
+### `BragDocumentGenerator`
+
+The main class for generating brag documents.
+
+```python
+from brag.agents import BragDocumentGenerator
+
+generator = BragDocumentGenerator(
+    model="openai:gpt-4o",
+    language="English"
+)
+
+brag_document = generator.generate_brag_document(commits)
+```
+
+#### Parameters
+
+- `model`: The name of the AI model to use for generating the brag document.
+- `language`: The language to use for generating the brag document.
+
+#### Methods
+
+- `generate_brag_document(commits)`: Generates a brag document from a list of commits.
+
+### `get_commits_for_user`
+
+Function to retrieve commits for a specific user in a repository.
+
+```python
+from brag.github_commits import get_commits_for_user
+
+commits = get_commits_for_user(
+    repo_name="owner/repo",
+    username="github-username",
+    token="github-api-token",
+    from_date="2023-01-01",
+    to_date="2023-12-31",
+    limit=50
+)
+```
+
+#### Parameters
+
+- `repo_name`: The name of the repository (in the format "owner/repo").
+- `username`: The GitHub username to get commits for.
+- `token`: The GitHub API token for authentication (optional).
+- `from_date`: The start date to get commits from (format: YYYY-MM-DD).
+- `to_date`: The end date to get commits to (format: YYYY-MM-DD).
+- `limit`: The maximum number of commits to retrieve.
+
+### `Repository`
+
+Class for working with Git repositories.
+
+```python
+from brag.repository import Repository
+
+repo = Repository.from_name("owner/repo", token="github-api-token")
+```
+
+#### Class Methods
+
+- `from_name(repo_name, token=None)`: Creates a Repository instance from a repository name.
+
+## Usage Examples
+
+### Generating a Brag Document Programmatically
+
+```python
+from brag.github_commits import get_commits_for_user
+from brag.agents import BragDocumentGenerator
+
+# Get commits for a user
+commits = get_commits_for_user(
+    repo_name="owner/repo",
+    username="github-username",
+    token="github-api-token",
+    from_date="2023-01-01",
+    to_date="2023-12-31"
+)
+
+# Generate a brag document
+generator = BragDocumentGenerator(model="openai:gpt-4o")
+brag_document = generator.generate_brag_document(commits)
+
+# Print or save the brag document
+print(brag_document)
+# Or
+with open("brag.md", "w") as f:
+    f.write(brag_document)
+```
+
+### Using Custom Formatters
+
+```python
+from brag.github_commits import get_commits_for_user
+from brag.agents import BragDocumentGenerator
+from brag.text_formatters import markdown_formatter
+
+# Get commits
+commits = get_commits_for_user(repo_name="owner/repo", username="github-username")
+
+# Generate brag document
+generator = BragDocumentGenerator()
+brag_document = generator.generate_brag_document(commits)
+
+# Format the brag document
+formatted_document = markdown_formatter(brag_document)
+
+# Save the formatted document
+with open("brag.md", "w") as f:
+    f.write(formatted_document)
+```
+
+## Error Handling
+
+When using the Brag AI API, you might encounter various errors. Here's how to handle them:
+
+```python
+from brag.github_commits import get_commits_for_user
+import github.GithubException
+
+try:
+    commits = get_commits_for_user(repo_name="owner/repo", username="github-username")
+except github.GithubException as e:
+    if e.status == 404:
+        print("Repository or user not found")
+    elif e.status == 401:
+        print("Authentication failed, check your token")
+    else:
+        print(f"GitHub API error: {e}")
+except Exception as e:
+    print(f"Error: {e}")
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,114 @@
+# Configuration
+
+Brag AI offers several configuration options to customize its behavior. This guide explains the different ways to configure Brag AI.
+
+## Environment Variables
+
+Brag AI supports the following environment variables:
+
+### Authentication Tokens
+
+| Environment Variable | Description                                                                                        |
+| -------------------- | -------------------------------------------------------------------------------------------------- |
+| `GITHUB_API_TOKEN`   | GitHub API token for authentication (required for private repositories or to increase rate limits) |
+| `OPENAI_API_KEY`     | OpenAI API key for using OpenAI models                                                             |
+| `ANTHROPIC_API_KEY`  | Anthropic API key for using Claude models                                                          |
+| `GEMINI_API_KEY`     | Google API key for using Gemini models                                                             |
+
+You can set these environment variables in your shell profile or use a `.env` file in your project directory.
+
+Example `.env` file:
+
+```
+GITHUB_API_TOKEN=ghp_your_github_token
+OPENAI_API_KEY=sk-your_openai_key
+```
+
+### Environment Variable Precedence
+
+Environment variables take precedence over command-line arguments. For example, if you set `GITHUB_API_TOKEN` in your environment and also provide `--github-api-token` on the command line, the environment variable will be used.
+
+## Command-Line Options
+
+Brag AI has several command-line options that can be used to configure its behavior:
+
+### Repository Selection
+
+| Option       | Description                                                                    |
+| ------------ | ------------------------------------------------------------------------------ |
+| `owner/repo` | The GitHub repository to generate the brag document from (positional argument) |
+| `--user`     | The GitHub username to generate the brag document for                          |
+
+### Time Range
+
+| Option    | Description                                                           |
+| --------- | --------------------------------------------------------------------- |
+| `--from`  | The start date to generate the brag document for (format: YYYY-MM-DD) |
+| `--to`    | The end date to generate the brag document for (format: YYYY-MM-DD)   |
+| `--limit` | The maximum number of commits to include in the brag document         |
+
+### Authentication
+
+| Option               | Description                                    |
+| -------------------- | ---------------------------------------------- |
+| `--github-api-token` | The GitHub API token to use for authentication |
+
+### Output
+
+| Option        | Description                                             |
+| ------------- | ------------------------------------------------------- |
+| `--output`    | The path to save the generated brag document            |
+| `--overwrite` | If set, overwrites the output file if it already exists |
+
+### AI Model Configuration
+
+| Option       | Description                                                      |
+| ------------ | ---------------------------------------------------------------- |
+| `--model`    | The name of the AI model to use for generating the brag document |
+| `--language` | The language to use for generating the brag document             |
+
+## Model Selection
+
+Brag AI supports a variety of AI models through `pydantic-ai`. You can specify which model to use with the `--model` option.
+
+The format for the model name is `provider:model-name`. For example:
+
+- `openai:gpt-4o`
+- `anthropic:claude-3-5-sonnet-latest`
+- `google-vertex:gemini-2.0-flash`
+
+For a full list of supported models, see the [pydantic-ai documentation](https://ai.pydantic.dev/models/).
+
+## Default Values
+
+If not specified, Brag AI uses the following default values:
+
+- User: The owner of the GitHub API token
+- From date: None (no lower bound)
+- To date: None (the current date)
+- Limit: None (no limit)
+- Output: stdout (print to console)
+- Model: The default model configured in pydantic-ai
+- Language: English
+
+## Example Configurations
+
+### Generate a brag document for contributions in 2023 using GPT-4o
+
+```bash
+export OPENAI_API_KEY=your-openai-api-key
+brag owner/repo --user github-username --from 2023-01-01 --to 2023-12-31 --model openai:gpt-4o
+```
+
+### Generate a brag document in Portuguese using Claude
+
+```bash
+export ANTHROPIC_API_KEY=your-anthropic-api-key
+brag owner/repo --user github-username --language Português --model anthropic:claude-3-5-sonnet-latest
+```
+
+### Save the brag document to a file and limit to the last 50 commits
+
+```bash
+brag owner/repo --user github-username --limit 50 --output brag.md
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,141 @@
+# Contributing to Brag AI 🎈
+
+So you want to contribute to Brag AI? Awesome! We're thrilled to have you join our quest to make bragging (about
+your achievements) an automated art form. Here's how you can help:
+
+## Getting Started
+
+1.  **Fork the repository**: Click the "Fork" button at the top right of the [GitHub repository](https://github.com/ruancomelli/brag-ai).
+2.  **Clone your fork**:
+
+    ```bash
+    git clone https://github.com/your-username/brag-ai.git
+    cd brag-ai
+    ```
+
+3.  **Set up your development environment**: We use `uv` to manage our dependencies. Initialize your environment with:
+
+    ```bash
+    bash scripts/init.sh
+    ```
+
+    This will:
+
+    - Install all the required dev dependencies; and
+    - Set up pre-commit hooks
+
+4.  **Create a branch**:
+
+    ```bash
+    git checkout -b your-awesome-feature-name
+    ```
+
+## Making Changes
+
+1.  **Make your changes**: Go wild! But please, keep the code clean and well-documented.
+2.  **Test your changes**: Run the tests to make sure you haven't broken anything:
+
+    ```bash
+    bash scripts/test.sh
+    ```
+
+    To run tests with coverage:
+
+    ```bash
+    bash scripts/test-cov.sh
+    ```
+
+3.  **Format your code**: Keep the code style consistent by running:
+
+    ```bash
+    bash scripts/format.sh
+    ```
+
+4.  **Lint your code**: Catch those pesky little errors with:
+
+    ```bash
+    bash scripts/lint.sh
+    ```
+
+5.  **Type-check your code**: Ensure type correctness by running:
+
+    ```bash
+    bash scripts/type-check.sh
+    ```
+
+6.  **Commit your changes**:
+
+    ```bash
+    git add .
+    git commit -m "feat: Add your awesome feature"
+    ```
+
+    Make sure your commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) format.
+
+7.  **Push to your fork**:
+
+    ```bash
+    git push origin your-awesome-feature-name
+    ```
+
+## Submitting a Pull Request
+
+1.  **Create a pull request**: Go to your fork on GitHub and click the "Create Pull Request" button.
+2.  **Describe your changes**: Provide a clear and concise description of your changes.
+3.  **Wait for review**: Our team will review your pull request and provide feedback.
+4.  **Address feedback**: Make any necessary changes based on the feedback.
+5.  **Get merged!**: Once your pull request is approved, it will be merged into the main branch. Congratulations,
+    you're now a Brag AI contributor! 🎉
+
+## Useful Scripts
+
+We have a few utility scripts in the `scripts/` directory to help you with development:
+
+- `scripts/init.sh`: Initializes the development environment by installing dependencies and setting up pre-commit hooks.
+- `scripts/test.sh`: Runs the tests. If invoked without arguments, it runs all tests. If invoked with test names, it runs only those tests.
+- `scripts/test-cov.sh`: Runs the tests with coverage.
+- `scripts/format.sh`: Formats the code. If invoked without arguments, it formats the entire codebase. If invoked with file paths, it formats only those files.
+- `scripts/lint.sh`: Lints the code. If invoked without arguments, it lints the entire codebase. If invoked with file paths, it lints only those files.
+- `scripts/type-check.sh`: Type-checks the code. If invoked without arguments, it type-checks the entire codebase. If invoked with file paths, it type-checks only those files.
+
+## Contributing to Documentation
+
+If you want to contribute to the documentation, you'll need to set up MkDocs:
+
+1. **Install MkDocs and the required dependencies**:
+
+   ```bash
+   uv add --group docs mkdocs mkdocs-material pymdown-extensions
+   ```
+
+2. **Make your changes** to the Markdown files in the `docs/` directory.
+
+3. **Preview your changes** by running the MkDocs development server:
+
+   ```bash
+   uv run --group docs mkdocs serve
+   ```
+
+4. **Build the documentation** to verify that it builds successfully:
+
+   ```bash
+   uv run --group docs mkdocs build --strict
+   ```
+
+5. **Commit and push your changes** as normal.
+
+## Code Style Guidelines
+
+We follow these general guidelines for code style:
+
+- Use [ruff](https://github.com/astral-sh/ruff) for linting and formatting
+- Follow [PEP 8](https://peps.python.org/pep-0008/) style guidelines
+- Use type hints for all function parameters and return values
+- Write docstrings for all modules, classes, and functions
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages
+
+## Have Fun!
+
+We're all here to learn and grow together. Don't be afraid to ask questions, experiment, and have fun! ✨
+However, keep in mind that we're all volunteers, so please be patient and respectful when waiting for feedback.
+It is also of utmost importance to be respectful - treat others as you would like to be treated.

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1,0 +1,139 @@
+/* Brag AI Documentation Custom Styles */
+
+/* Custom colors and fonts */
+:root {
+	--md-primary-fg-color: #7c4dff;
+	--md-primary-fg-color--light: #c5b3ff;
+	--md-primary-fg-color--dark: #4a2fe3;
+	--md-accent-fg-color: #ff4081;
+}
+
+/* Emoji styling */
+.md-typeset .emojione,
+.md-typeset .twemoji {
+	vertical-align: -0.2em;
+}
+
+/* Code blocks */
+.md-typeset code {
+	border-radius: 3px;
+	font-size: 0.9em;
+}
+
+.md-typeset pre {
+	border-radius: 5px;
+}
+
+/* Admonitions */
+.md-typeset .admonition,
+.md-typeset details {
+	border-radius: 5px;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, .1);
+}
+
+/* Tables */
+.md-typeset table:not([class]) {
+	box-shadow: 0 2px 4px rgba(0, 0, 0, .05);
+	border-radius: 5px;
+}
+
+.md-typeset table:not([class]) th {
+	background-color: var(--md-primary-fg-color--light);
+	color: #333;
+}
+
+/* Permalink icon */
+.md-typeset .headerlink {
+	opacity: 0.5;
+}
+
+.md-typeset h1:hover .headerlink,
+.md-typeset h2:hover .headerlink,
+.md-typeset h3:hover .headerlink,
+.md-typeset h4:hover .headerlink,
+.md-typeset h5:hover .headerlink,
+.md-typeset h6:hover .headerlink {
+	opacity: 1;
+}
+
+/* Hero */
+.md-typeset .hero {
+	margin: 2em 0;
+	text-align: center;
+}
+
+.md-typeset .hero img {
+	max-width: 300px;
+	margin: 0 auto;
+	display: block;
+}
+
+/* Buttons */
+.md-button {
+	border-radius: 3px;
+	transition: all 0.3s;
+}
+
+.md-button:hover {
+	transform: translateY(-1px);
+	box-shadow: 0 3px 6px rgba(0, 0, 0, .2);
+}
+
+/* Feature cards */
+.feature-card {
+	display: flex;
+	flex-direction: column;
+	margin: 1em 0;
+	padding: 1em;
+	background-color: #f8f9fa;
+	border-radius: 5px;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, .05);
+	transition: all 0.3s;
+}
+
+.feature-card:hover {
+	transform: translateY(-2px);
+	box-shadow: 0 4px 8px rgba(0, 0, 0, .1);
+}
+
+.feature-card h3 {
+	margin-top: 0;
+}
+
+/* Code annotations */
+.md-typeset .code-annotation-button {
+	background-color: var(--md-accent-fg-color);
+}
+
+/* Terminal blocks */
+.terminal {
+	background-color: #2d2d2d;
+	color: #f8f8f2;
+	padding: 1em;
+	border-radius: 5px;
+	font-family: monospace;
+	margin: 1em 0;
+}
+
+/* Navigation styling */
+.md-nav__item .md-nav__link--active {
+	font-weight: bold;
+	color: var(--md-accent-fg-color);
+}
+
+/* Footer */
+.md-footer-meta {
+	background-color: #212121;
+}
+
+/* Print styles */
+@media print {
+	.md-typeset a {
+		color: #000 !important;
+		text-decoration: underline;
+	}
+
+	.md-footer {
+		display: none;
+	}
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,264 @@
+# Development Guide
+
+This guide explains how to set up your development environment, understand the project structure, and contribute to the Brag AI codebase.
+
+## Project Structure
+
+The Brag AI project is organized as follows:
+
+```
+brag-ai/
+├── docs/                  # Documentation files
+├── scripts/               # Development utility scripts
+├── src/                   # Source code
+│   └── brag/              # Main package
+│       ├── __init__.py    # Package initialization
+│       ├── __main__.py    # CLI entry point
+│       ├── agents.py      # AI agent implementations
+│       ├── cli.py         # Command-line interface
+│       ├── github_commits.py  # GitHub API interactions
+│       ├── repository.py  # Repository abstractions
+│       └── text_formatters.py # Text formatting utilities
+├── tests/                 # Test files
+├── .env                   # Environment variables
+├── .gitignore             # Git ignore file
+├── .pre-commit-config.yaml # Pre-commit hooks configuration
+├── pyproject.toml         # Project configuration
+└── README.md              # Project README
+```
+
+## Development Environment Setup
+
+### Prerequisites
+
+- Python 3.12 or higher
+- [uv](https://docs.astral.sh/uv/) (recommended for dependency management)
+- Git
+
+### Setting Up Your Environment
+
+1. **Clone the repository**:
+
+   ```bash
+   git clone https://github.com/ruancomelli/brag-ai.git
+   cd brag-ai
+   ```
+
+2. **Initialize the development environment**:
+
+   ```bash
+   bash scripts/init.sh
+   ```
+
+   This script:
+
+   - Creates a virtual environment
+   - Installs development dependencies
+   - Sets up pre-commit hooks
+
+3. **Set up environment variables**:
+
+   Create a `.env` file in the project root:
+
+   ```
+   GITHUB_API_TOKEN=your_github_token
+   OPENAI_API_KEY=your_openai_key
+   ```
+
+   This file is listed in `.gitignore` so you don't accidentally commit your tokens.
+
+## Development Workflow
+
+### Making Code Changes
+
+1. **Create a branch**:
+
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+2. **Make your changes**.
+
+3. **Run tests to ensure your changes work**:
+
+   ```bash
+   bash scripts/test.sh
+   ```
+
+4. **Format your code**:
+
+   ```bash
+   bash scripts/format.sh
+   ```
+
+5. **Lint your code**:
+
+   ```bash
+   bash scripts/lint.sh
+   ```
+
+6. **Type-check your code**:
+
+   ```bash
+   bash scripts/type-check.sh
+   ```
+
+7. **Commit your changes using [Conventional Commits](https://www.conventionalcommits.org/) format**:
+
+   ```bash
+   git commit -m "feat: Add new feature"
+   ```
+
+8. **Push your changes**:
+
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+
+9. **Open a pull request** on GitHub.
+
+### Running the Application Locally
+
+To run the application locally during development:
+
+```bash
+uv run src/brag/__main__.py --help
+```
+
+Or, if you've installed the package in development mode:
+
+```bash
+brag --help
+```
+
+## Testing
+
+### Running Tests
+
+Run all tests:
+
+```bash
+bash scripts/test.sh
+```
+
+Run specific tests:
+
+```bash
+bash scripts/test.sh tests/test_specific.py
+```
+
+Run tests with coverage:
+
+```bash
+bash scripts/test-cov.sh
+```
+
+This will generate a coverage report in the terminal and a `coverage.xml` file.
+
+### Writing Tests
+
+Tests are located in the `tests/` directory. We use pytest for testing.
+
+When adding a new feature, please add corresponding tests. Aim for high test coverage and make sure to test edge cases.
+
+Example test structure:
+
+```python
+# tests/test_feature.py
+import pytest
+from brag.feature import my_function
+
+def test_my_function_happy_path():
+    # Test normal operation
+    result = my_function(input)
+    assert result == expected
+
+def test_my_function_edge_case():
+    # Test edge case
+    with pytest.raises(ValueError):
+        my_function(bad_input)
+```
+
+## Documentation
+
+### Updating Documentation
+
+Documentation is built using MkDocs and the Material theme. Source files are in the `docs/` directory.
+
+To preview documentation changes:
+
+```bash
+uv run --group docs mkdocs serve
+```
+
+This starts a local web server at http://127.0.0.1:8000/ where you can preview your changes.
+
+To build the documentation:
+
+```bash
+uv run --group docs mkdocs build --strict
+```
+
+### Documentation Style Guide
+
+- Use clear, concise language
+- Include code examples where appropriate
+- Format code blocks with syntax highlighting
+- Use heading levels appropriately
+- Include links to related documentation
+
+## Code Style
+
+We follow these style guidelines:
+
+- Use [ruff](https://github.com/astral-sh/ruff) for linting and formatting
+- Follow [PEP 8](https://peps.python.org/pep-0008/) style guidelines
+- Use type hints for all function parameters and return values
+- Write docstrings for all modules, classes, and functions
+- Use descriptive variable and function names
+
+## Debugging
+
+### Logging
+
+The application uses [loguru](https://github.com/Delgan/loguru) for logging. You can enable debug logs by setting the environment variable:
+
+```bash
+export LOGURU_LEVEL=DEBUG
+```
+
+### Debugging Tests
+
+To debug tests with pytest, you can use the `-v` (verbose) flag:
+
+```bash
+pytest -v tests/test_feature.py
+```
+
+## CI/CD
+
+The project uses GitHub Actions for continuous integration and deployment. The workflows are defined in the `.github/workflows/` directory.
+
+The CI workflow runs on every pull request and checks:
+
+- Code formatting
+- Linting
+- Type checking
+- Test execution
+- Documentation building
+
+## Need Help?
+
+If you're stuck or have questions, you can:
+
+- Open an issue on GitHub
+- Start a discussion in the GitHub Discussions section
+- Check the existing documentation and issues for similar problems
+
+## Tips and Tricks
+
+- Use the development scripts in the `scripts/` directory to automate common tasks
+- Keep PRs focused on a single feature or bug fix
+- Add comments explaining complex logic
+- Write tests before implementing features (TDD)
+- Use descriptive commit messages to make the project history easier to understand

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,71 @@
+# 💁 Brag AI
+
+Generate and maintain a brag document automatically from your GitHub contributions, powered by AI.
+
+Because your awesome work deserves to be remembered! ✨
+
+<p align="center">
+<img src="assets/hero.webp" alt="Brag AI Hero" width="300">
+</p>
+
+## Overview
+
+Ever had that moment when your manager asks "So, what have you been up to?" and your mind goes blank?
+
+Brag AI is your personal achievement historian! It helps you create and maintain a "brag document" - a fancy record of all the cool stuff you've done. It dives into your GitHub activity and transforms those cryptic commit messages into beautiful, human-readable achievements that will make your portfolio shine! ✨
+
+Perfect for:
+
+- 📊 Performance reviews (without the last-minute panic)
+- 💼 Job applications (show off with style)
+- 📈 Personal development tracking (watch yourself grow!)
+- 🎉 Impressing your friends (and maybe your pet - results may vary)
+
+## Features
+
+- 🔍 **GitHub Integration**: Automagically analyzes your commits to generate achievement descriptions
+- 🤖 **AI-Powered**: Turns "fix: bug in login" into "Enhanced system reliability by resolving critical authentication issues"
+- 💻 **CLI Tool**: Easy to use command-line interface
+
+## Getting Started
+
+Check out the [Installation](installation.md) guide to get Brag AI up and running on your system.
+
+Then head over to the [Usage](usage.md) guide to learn how to generate your first brag document.
+
+## Coming Soon™ 🚀
+
+- 🌐 **Web Interface**: Because sometimes clicking is better than typing
+- 🤝 **Extended GitHub Integration**: Support for PR reviews, issues, and discussions
+- 🔄 **Integration with other tools**: GitLab, Bitbucket, and more - we don't discriminate!
+- 📝 **Custom Templates**: Make your brag document as unique as you are
+- 📦 **Export Options**: More ways to show off your achievements (JSON brag documents anyone?)
+- 🔒 **Local Processing**: Your precious data stays on your machine if you use local LLMs
+
+## Community
+
+Got ideas? We'd love to hear them! Check out our [Contributing Guide](contributing.md) to join the fun! 🎈
+
+## License
+
+<!-- TODO: switch to MIT -->
+
+This project is currently private (shhh... 🤫)
+
+## Support
+
+- 📖 [Documentation](https://ruancomelli.github.io/brag-ai/)
+- 🐛 [Issue Tracker](https://github.com/ruancomelli/brag-ai/issues)
+- 💬 [Discussions](https://github.com/ruancomelli/brag-ai/discussions)
+- 💻 [Repository](https://github.com/ruancomelli/brag-ai)
+
+## Why Brag AI?
+
+Maintaining a brag document is crucial for career development, but it's often overlooked or forgotten until it's time for a performance review.
+Brag AI automates this process, helping you capture your achievements while they're fresh or after a long time.
+
+---
+
+Built with ❤️ and ☕ by [Ruan Comelli](https://github.com/ruancomelli)
+
+_Remember: It's not bragging if it's true! ✨_

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,78 @@
+# Installation
+
+There are several ways to install Brag AI, depending on your needs and preferences.
+
+## Requirements
+
+- Python 3.12 or higher
+- A GitHub account (for generating brag documents from GitHub repositories)
+- An API key for at least one AI provider (OpenAI, Anthropic, or Google) if you want to use their models
+
+## Installation Methods
+
+### From Source (Recommended for Now)
+
+This project is still not published to PyPI. You can install it from source using pip:
+
+```bash
+pip install git+https://github.com/ruancomelli/brag-ai.git
+```
+
+### Using `uv`
+
+If you use [`uv`](https://docs.astral.sh/uv/), you can also run this tool using
+`uvx` tool calling without installation:
+
+```bash
+uvx --from git+https://github.com/ruancomelli/brag-ai brag --help # or any other command
+```
+
+## Verifying Your Installation
+
+To verify that Brag AI was installed correctly, run:
+
+```bash
+brag --version
+```
+
+You should see the current version number printed to the console.
+
+## Setting Up API Keys
+
+Brag AI uses `pydantic-ai` under the hood, which supports [various AI models](https://ai.pydantic.dev/models/).
+
+To use these models, you'll need to set up API keys as environment variables:
+
+### OpenAI
+
+```bash
+export OPENAI_API_KEY=your-openai-api-key
+```
+
+### Anthropic
+
+```bash
+export ANTHROPIC_API_KEY=your-anthropic-api-key
+```
+
+### Google (Gemini)
+
+```bash
+export GEMINI_API_KEY=your-gemini-api-key
+```
+
+You can set these environment variables in your shell profile or use a `.env` file in your project directory.
+
+## GitHub Authentication
+
+For accessing private GitHub repositories or increasing your rate limit, you can provide a GitHub API token:
+
+```bash
+export GITHUB_API_TOKEN=your-github-api-token
+```
+
+You can generate a Personal Access Token from your GitHub account settings. For more information, see GitHub's documentation on [Creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+
+## Next Steps
+
+Now that you have Brag AI installed, check out the [Usage Guide](usage.md) to learn how to generate your first brag document!

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,38 @@
+# Release Notes
+
+This page contains the release notes for Brag AI, documenting the changes and improvements in each version.
+
+## Unreleased
+
+### Added
+
+- Initial release of Brag AI
+- GitHub integration for retrieving commits
+- AI-powered brag document generation
+- Command-line interface
+- Support for multiple AI providers (OpenAI, Anthropic, Google)
+- Customizable language output
+- Comprehensive documentation
+
+### Changed
+
+- N/A (Initial release)
+
+### Fixed
+
+- N/A (Initial release)
+
+## Future Plans
+
+Here are some features and improvements planned for future releases:
+
+- Web interface for easier interaction
+- Extended GitHub integration (PR reviews, issues, and discussions)
+- Integration with other Git platforms (GitLab, Bitbucket)
+- Custom templates for brag documents
+- Additional export options (JSON, HTML, PDF)
+- Local LLM support for offline processing
+- Team collaboration features
+- Performance improvements for large repositories
+
+Stay tuned for these exciting updates!

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,105 @@
+# Usage Guide
+
+Brag AI is designed to be simple to use while providing powerful functionality. This guide will walk you through the basic and advanced usage of the tool.
+
+## Basic Usage
+
+The most basic way to use Brag AI is to generate a brag document from a GitHub repository:
+
+```bash
+brag owner/repo --user github-username
+```
+
+This will generate a brag document based on the commits made by `github-username` to the specified repository.
+
+## Command Line Options
+
+Brag AI offers several command line options to customize the generated brag document:
+
+| Option               | Description                                                                                                             |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `--user`             | The GitHub username to generate the brag document for. If not provided, the owner of the GitHub API token will be used. |
+| `--from`             | The start date to generate the brag document for (format: YYYY-MM-DD).                                                  |
+| `--to`               | The end date to generate the brag document for (format: YYYY-MM-DD).                                                    |
+| `--limit`            | The maximum number of commits to include in the brag document.                                                          |
+| `--github-api-token` | The GitHub API token to use for authentication. If not provided, only public information will be included.              |
+| `--output`           | The path to save the generated brag document. If not specified, the document will be printed to stdout.                 |
+| `--overwrite`        | If set, overwrites the output file if it already exists.                                                                |
+| `--model`            | The name of the AI model to use for generating the brag document.                                                       |
+| `--language`         | The language to use for generating the brag document.                                                                   |
+
+## Examples
+
+Here are some examples of how to use Brag AI in different scenarios:
+
+### Generate a Brag Document for a Specific Time Period
+
+```bash
+brag my-org/my-repo --user my-username --from 2023-01-01 --to 2023-12-31
+```
+
+This will generate a brag document for the user `my-username` based on their contributions to the `my-org/my-repo` repository between January 1, 2023, and December 31, 2023.
+
+### Generate a Brag Document in a Different Language
+
+```bash
+brag my-org/my-repo --user my-username --language Português
+```
+
+This will generate a brag document in Portuguese.
+
+### Save the Brag Document to a File
+
+```bash
+brag my-org/my-repo --user my-username --output brag.md
+```
+
+This will save the generated brag document to a file named `brag.md`.
+
+### Combine Multiple Options
+
+```bash
+brag my-org/my-repo --user my-username \
+  --from 2023-01-01 --to 2023-12-31 \
+  --language Português \
+  --output brag.md
+```
+
+This combines multiple options to generate a brag document in Portuguese for a specific time period and save it to a file.
+
+## Using Different AI Models
+
+Brag AI supports various AI models through `pydantic-ai`. You can specify which model to use with the `--model` option:
+
+### OpenAI Models
+
+```bash
+export OPENAI_API_KEY=your-openai-api-key
+brag --model openai:gpt-4o owner/repo --user github-username
+```
+
+### Anthropic Models
+
+```bash
+export ANTHROPIC_API_KEY=your-anthropic-api-key
+brag --model anthropic:claude-3-5-sonnet-latest owner/repo --user github-username
+```
+
+### Google Models
+
+```bash
+export GEMINI_API_KEY=your-gemini-api-key
+brag --model google-vertex:gemini-2.0-flash owner/repo --user github-username
+```
+
+## Viewing Help Information
+
+For a complete list of commands and options, use the `--help` flag:
+
+```bash
+brag --help
+```
+
+## Next Steps
+
+Now that you know how to use Brag AI, you might want to check out the [Configuration Guide](configuration.md) for more advanced options or the [API Reference](api-reference.md) if you want to use Brag AI programmatically.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,107 @@
+strict: true
+site_name: Brag AI
+site_description: Generate and maintain a brag document automatically from your GitHub contributions, powered by AI.
+site_url: https://ruancomelli.github.io/brag-ai
+docs_dir: docs
+site_dir: site
+dev_addr: 127.0.0.1:8000
+repo_url: https://github.com/ruancomelli/brag-ai
+edit_uri: edit/main/docs
+
+nav:
+- Welcome: index.md
+- installation.md
+- usage.md
+- configuration.md
+- api-reference.md
+- contributing.md
+- development.md
+- release-notes.md
+- External links:
+  - GitHub 🔗: https://github.com/ruancomelli/brag-ai
+
+plugins:
+- search
+- social
+
+theme:
+  name: material
+  logo: assets/hero.webp
+  favicon: assets/hero.webp
+  palette:
+    # Palette toggle for automatic mode
+  - media: (prefers-color-scheme)
+    toggle:
+      icon: material/brightness-auto
+      name: Switch to light mode
+
+    # Palette toggle for light mode
+  - media: '(prefers-color-scheme: light)'
+    scheme: default
+    toggle:
+      icon: material/brightness-7
+      name: Switch to dark mode
+
+    # Palette toggle for dark mode
+  - media: '(prefers-color-scheme: dark)'
+    scheme: slate
+    toggle:
+      icon: material/brightness-4
+      name: Switch to system preference
+  icon:
+    annotation: material/arrow-right-circle
+    repo: fontawesome/brands/github
+  features:
+  - navigation.expand
+  - navigation.footer
+  - navigation.sections
+  - navigation.tracking
+  - content.action.edit
+  - content.action.view
+  - content.code.copy
+  - content.code.annotate
+
+markdown_extensions:
+- admonition
+- pymdownx.details
+- pymdownx.magiclink:
+    repo_url_shorthand: true
+    normalize_issue_symbols: true
+    provider: github
+    user: ruancomelli
+    repo: brag-ai
+- pymdownx.snippets:
+    base_path:
+    - docs/snippets
+    check_paths: true
+- pymdownx.superfences
+- pymdownx.tabbed:
+    alternate_style: true
+- md_in_html
+- attr_list
+- toc:
+    permalink: 🔗
+- pymdownx.highlight:
+    anchor_linenums: true
+    line_spans: __span
+    pygments_lang_class: true
+- pymdownx.inlinehilite
+
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+
+extra_css:
+- css/extra.css
+
+exclude_docs: |
+  snippets/
+
+extra:
+  social:
+  - icon: fontawesome/brands/github
+    link: https://github.com/ruancomelli/brag-ai
+    name: ruancomelli/brag-ai on GitHub
+
+copyright: '&copy; 2024 Ruan Comelli'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,11 @@ type-check = ["mypy>=1.15.0"]
 test = ["pytest>=8.3.4"]
 test-cov = ["pytest>=8.3.4", "pytest-cov>=6.0.0"]
 pre-commit = ["pre-commit>=4.1.0"]
+docs = [
+    "mkdocs>=1.6.1",
+    "mkdocs-material[imaging]>=9.6.7",
+    "pymdown-extensions>=10.14.3",
+]
 
 [tool.mypy]
 plugins = ['pydantic.mypy']

--- a/scripts/docs-build.sh
+++ b/scripts/docs-build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+uv run --only-group docs mkdocs build --strict

--- a/scripts/docs-serve.sh
+++ b/scripts/docs-serve.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+uv run --only-group docs mkdocs serve

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,28 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537 },
+]
+
+[[package]]
+name = "backrefs"
+version = "5.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/46/caba1eb32fa5784428ab401a5487f73db4104590ecd939ed9daaf18b47e0/backrefs-5.8.tar.gz", hash = "sha256:2cab642a205ce966af3dd4b38ee36009b31fa9502a35fd61d59ccc116e40a6bd", size = 6773994 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/cb/d019ab87fe70e0fe3946196d50d6a4428623dc0c38a6669c8cae0320fbf3/backrefs-5.8-py310-none-any.whl", hash = "sha256:c67f6638a34a5b8730812f5101376f9d41dc38c43f1fdc35cb54700f6ed4465d", size = 380337 },
+    { url = "https://files.pythonhosted.org/packages/a9/86/abd17f50ee21b2248075cb6924c6e7f9d23b4925ca64ec660e869c2633f1/backrefs-5.8-py311-none-any.whl", hash = "sha256:2e1c15e4af0e12e45c8701bd5da0902d326b2e200cafcd25e49d9f06d44bb61b", size = 392142 },
+    { url = "https://files.pythonhosted.org/packages/b3/04/7b415bd75c8ab3268cc138c76fa648c19495fcc7d155508a0e62f3f82308/backrefs-5.8-py312-none-any.whl", hash = "sha256:bbef7169a33811080d67cdf1538c8289f76f0942ff971222a16034da88a73486", size = 398021 },
+    { url = "https://files.pythonhosted.org/packages/04/b8/60dcfb90eb03a06e883a92abbc2ab95c71f0d8c9dd0af76ab1d5ce0b1402/backrefs-5.8-py313-none-any.whl", hash = "sha256:e3a63b073867dbefd0536425f43db618578528e3896fb77be7141328642a1585", size = 399915 },
+    { url = "https://files.pythonhosted.org/packages/0c/37/fb6973edeb700f6e3d6ff222400602ab1830446c25c7b4676d8de93e65b8/backrefs-5.8-py39-none-any.whl", hash = "sha256:a66851e4533fb5b371aa0628e1fee1af05135616b86140c9d787a2ffdf4b8fdc", size = 380336 },
+]
+
+[[package]]
 name = "brag"
 source = { editable = "." }
 dependencies = [
@@ -70,6 +92,11 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-material", extra = ["imaging"] },
+    { name = "pymdown-extensions" },
+]
 format = [
     { name = "ruff" },
 ]
@@ -103,6 +130,11 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
+docs = [
+    { name = "mkdocs", specifier = ">=1.6.1" },
+    { name = "mkdocs-material", extras = ["imaging"], specifier = ">=9.6.7" },
+    { name = "pymdown-extensions", specifier = ">=10.14.3" },
+]
 format = [{ name = "ruff", specifier = ">=0.9.7" }]
 lint = [{ name = "ruff", specifier = ">=0.9.7" }]
 pre-commit = [{ name = "pre-commit", specifier = ">=4.1.0" }]
@@ -120,6 +152,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080 },
+]
+
+[[package]]
+name = "cairocffi"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/c5/1a4dc131459e68a173cbdab5fad6b524f53f9c1ef7861b7698e998b837cc/cairocffi-1.7.1.tar.gz", hash = "sha256:2e48ee864884ec4a3a34bfa8c9ab9999f688286eb714a15a43ec9d068c36557b", size = 88096 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d8/ba13451aa6b745c49536e87b6bf8f629b950e84bd0e8308f7dc6883b67e2/cairocffi-1.7.1-py3-none-any.whl", hash = "sha256:9803a0e11f6c962f3b0ae2ec8ba6ae45e957a146a004697a1ac1bbf16b073b3f", size = 75611 },
+]
+
+[[package]]
+name = "cairosvg"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cairocffi" },
+    { name = "cssselect2" },
+    { name = "defusedxml" },
+    { name = "pillow" },
+    { name = "tinycss2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/e6/ec5900b724e3c44af7f6f51f719919137284e5da4aabe96508baec8a1b40/CairoSVG-2.7.1.tar.gz", hash = "sha256:432531d72347291b9a9ebfb6777026b607563fd8719c46ee742db0aef7271ba0", size = 8399085 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/a5/1866b42151f50453f1a0d28fc4c39f5be5f412a2e914f33449c42daafdf1/CairoSVG-2.7.1-py3-none-any.whl", hash = "sha256:8a5222d4e6c3f86f1f7046b63246877a63b49923a1cd202184c3a634ef546b3b", size = 43235 },
 ]
 
 [[package]]
@@ -324,6 +384,28 @@ wheels = [
 ]
 
 [[package]]
+name = "cssselect2"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tinycss2" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/86/fd7f58fc498b3166f3a7e8e0cddb6e620fe1da35b02248b1bd59e95dbaaa/cssselect2-0.8.0.tar.gz", hash = "sha256:7674ffb954a3b46162392aee2a3a0aedb2e14ecf99fcc28644900f4e6e3e9d3a", size = 35716 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/e7/aa315e6a749d9b96c2504a1ba0ba031ba2d0517e972ce22682e3fccecb09/cssselect2-0.8.0-py3-none-any.whl", hash = "sha256:46fc70ebc41ced7a32cd42d58b1884d72ade23d21e5a4eaaf022401c13f0e76e", size = 15454 },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604 },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.2.18"
 source = { registry = "https://pypi.org/simple" }
@@ -398,6 +480,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/79/68612ed99700e6413de42895aa725463e821a6b3be75c87fcce1b4af4c70/fsspec-2025.2.0.tar.gz", hash = "sha256:1c24b16eaa0a1798afa0337aa0db9b256718ab2a89c425371f5628d22c3b6afd", size = 292283 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/94/758680531a00d06e471ef649e4ec2ed6bf185356a7f9fbfbb7368a40bd49/fsspec-2025.2.0-py3-none-any.whl", hash = "sha256:9de2ad9ce1f85e1931858535bc882543171d197001a0a5eb2ddc04f1781ab95b", size = 184484 },
+]
+
+[[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034 },
 ]
 
 [[package]]
@@ -535,6 +629,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/92/b3130cbbf5591acf9ade8708c365f3238046ac7cb8ccba6e81abccb0ccff/jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb", size = 244674 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/0f/2ba5fbcd631e3e88689309dbe978c5769e883e4b84ebfe7da30b43275c5a/jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb", size = 134596 },
+]
+
+[[package]]
 name = "jiter"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -601,6 +707,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/28/3af612670f82f4c056911fbbbb42760255801b3068c48de792d354ff4472/markdown-3.7.tar.gz", hash = "sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2", size = 357086 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/08/83871f3c50fc983b88547c196d11cf8c3340e37c32d2e9d6152abe2c61f7/Markdown-3.7-py3-none-any.whl", hash = "sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803", size = 106349 },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -613,12 +728,59 @@ wheels = [
 ]
 
 [[package]]
+name = "markupsafe"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274 },
+    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348 },
+    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149 },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118 },
+    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993 },
+    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178 },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319 },
+    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352 },
+    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097 },
+    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601 },
+    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274 },
+    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352 },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122 },
+    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085 },
+    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978 },
+    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208 },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357 },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344 },
+    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101 },
+    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603 },
+    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510 },
+    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486 },
+    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480 },
+    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914 },
+    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796 },
+    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473 },
+    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114 },
+    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098 },
+    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208 },
+    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739 },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354 },
 ]
 
 [[package]]
@@ -636,6 +798,81 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/16/9d/aba193fdfe0fc7403efa380189143d965becfb1bc7df3230e5c7664f8c53/mistralai-1.5.0.tar.gz", hash = "sha256:fd94bc93bc25aad9c6dd8005b1a0bc4ba1250c6b3fbf855a49936989cc6e5c0d", size = 131647 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/e7/7147c75c383a975c58c33f8e7ee7dbbb0e7390fbcb1ecd321f63e4c73efd/mistralai-1.5.0-py3-none-any.whl", hash = "sha256:9372537719f87bd6f9feef4747d0bf1f4fbe971f8c02945ca4b4bf3c94571c97", size = 271559 },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451 },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521 },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/d7/93e19c9587e5f4ed25647890555d58cf484a4d412be7037dc17b9c9179d9/mkdocs_material-9.6.7.tar.gz", hash = "sha256:3e2c1fceb9410056c2d91f334a00cdea3215c28750e00c691c1e46b2a33309b4", size = 3947458 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/d3/12f22de41bdd9e576ddc459b38c651d68edfb840b32acaa1f46ae36845e3/mkdocs_material-9.6.7-py3-none-any.whl", hash = "sha256:8a159e45e80fcaadd9fbeef62cbf928569b93df954d4dc5ba76d46820caf7b47", size = 8696755 },
+]
+
+[package.optional-dependencies]
+imaging = [
+    { name = "cairosvg" },
+    { name = "pillow" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728 },
 ]
 
 [[package]]
@@ -707,6 +944,54 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746 },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191 },
+]
+
+[[package]]
+name = "pillow"
+version = "10.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/74/ad3d526f3bf7b6d3f408b73fde271ec69dfac8b81341a318ce825f2b3812/pillow-10.4.0.tar.gz", hash = "sha256:166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06", size = 46555059 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/cb/0353013dc30c02a8be34eb91d25e4e4cf594b59e5a55ea1128fde1e5f8ea/pillow-10.4.0-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:673655af3eadf4df6b5457033f086e90299fdd7a47983a13827acf7459c15d94", size = 3509350 },
+    { url = "https://files.pythonhosted.org/packages/e7/cf/5c558a0f247e0bf9cec92bff9b46ae6474dd736f6d906315e60e4075f737/pillow-10.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:866b6942a92f56300012f5fbac71f2d610312ee65e22f1aa2609e491284e5597", size = 3374980 },
+    { url = "https://files.pythonhosted.org/packages/84/48/6e394b86369a4eb68b8a1382c78dc092245af517385c086c5094e3b34428/pillow-10.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29dbdc4207642ea6aad70fbde1a9338753d33fb23ed6956e706936706f52dd80", size = 4343799 },
+    { url = "https://files.pythonhosted.org/packages/3b/f3/a8c6c11fa84b59b9df0cd5694492da8c039a24cd159f0f6918690105c3be/pillow-10.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf2342ac639c4cf38799a44950bbc2dfcb685f052b9e262f446482afaf4bffca", size = 4459973 },
+    { url = "https://files.pythonhosted.org/packages/7d/1b/c14b4197b80150fb64453585247e6fb2e1d93761fa0fa9cf63b102fde822/pillow-10.4.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f5b92f4d70791b4a67157321c4e8225d60b119c5cc9aee8ecf153aace4aad4ef", size = 4370054 },
+    { url = "https://files.pythonhosted.org/packages/55/77/40daddf677897a923d5d33329acd52a2144d54a9644f2a5422c028c6bf2d/pillow-10.4.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:86dcb5a1eb778d8b25659d5e4341269e8590ad6b4e8b44d9f4b07f8d136c414a", size = 4539484 },
+    { url = "https://files.pythonhosted.org/packages/40/54/90de3e4256b1207300fb2b1d7168dd912a2fb4b2401e439ba23c2b2cabde/pillow-10.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:780c072c2e11c9b2c7ca37f9a2ee8ba66f44367ac3e5c7832afcfe5104fd6d1b", size = 4477375 },
+    { url = "https://files.pythonhosted.org/packages/13/24/1bfba52f44193860918ff7c93d03d95e3f8748ca1de3ceaf11157a14cf16/pillow-10.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:37fb69d905be665f68f28a8bba3c6d3223c8efe1edf14cc4cfa06c241f8c81d9", size = 4608773 },
+    { url = "https://files.pythonhosted.org/packages/55/04/5e6de6e6120451ec0c24516c41dbaf80cce1b6451f96561235ef2429da2e/pillow-10.4.0-cp312-cp312-win32.whl", hash = "sha256:7dfecdbad5c301d7b5bde160150b4db4c659cee2b69589705b6f8a0c509d9f42", size = 2235690 },
+    { url = "https://files.pythonhosted.org/packages/74/0a/d4ce3c44bca8635bd29a2eab5aa181b654a734a29b263ca8efe013beea98/pillow-10.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:1d846aea995ad352d4bdcc847535bd56e0fd88d36829d2c90be880ef1ee4668a", size = 2554951 },
+    { url = "https://files.pythonhosted.org/packages/b5/ca/184349ee40f2e92439be9b3502ae6cfc43ac4b50bc4fc6b3de7957563894/pillow-10.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:e553cad5179a66ba15bb18b353a19020e73a7921296a7979c4a2b7f6a5cd57f9", size = 2243427 },
+    { url = "https://files.pythonhosted.org/packages/c3/00/706cebe7c2c12a6318aabe5d354836f54adff7156fd9e1bd6c89f4ba0e98/pillow-10.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8bc1a764ed8c957a2e9cacf97c8b2b053b70307cf2996aafd70e91a082e70df3", size = 3525685 },
+    { url = "https://files.pythonhosted.org/packages/cf/76/f658cbfa49405e5ecbfb9ba42d07074ad9792031267e782d409fd8fe7c69/pillow-10.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6209bb41dc692ddfee4942517c19ee81b86c864b626dbfca272ec0f7cff5d9fb", size = 3374883 },
+    { url = "https://files.pythonhosted.org/packages/46/2b/99c28c4379a85e65378211971c0b430d9c7234b1ec4d59b2668f6299e011/pillow-10.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bee197b30783295d2eb680b311af15a20a8b24024a19c3a26431ff83eb8d1f70", size = 4339837 },
+    { url = "https://files.pythonhosted.org/packages/f1/74/b1ec314f624c0c43711fdf0d8076f82d9d802afd58f1d62c2a86878e8615/pillow-10.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ef61f5dd14c300786318482456481463b9d6b91ebe5ef12f405afbba77ed0be", size = 4455562 },
+    { url = "https://files.pythonhosted.org/packages/4a/2a/4b04157cb7b9c74372fa867096a1607e6fedad93a44deeff553ccd307868/pillow-10.4.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:297e388da6e248c98bc4a02e018966af0c5f92dfacf5a5ca22fa01cb3179bca0", size = 4366761 },
+    { url = "https://files.pythonhosted.org/packages/ac/7b/8f1d815c1a6a268fe90481232c98dd0e5fa8c75e341a75f060037bd5ceae/pillow-10.4.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e4db64794ccdf6cb83a59d73405f63adbe2a1887012e308828596100a0b2f6cc", size = 4536767 },
+    { url = "https://files.pythonhosted.org/packages/e5/77/05fa64d1f45d12c22c314e7b97398ffb28ef2813a485465017b7978b3ce7/pillow-10.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd2880a07482090a3bcb01f4265f1936a903d70bc740bfcb1fd4e8a2ffe5cf5a", size = 4477989 },
+    { url = "https://files.pythonhosted.org/packages/12/63/b0397cfc2caae05c3fb2f4ed1b4fc4fc878f0243510a7a6034ca59726494/pillow-10.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b35b21b819ac1dbd1233317adeecd63495f6babf21b7b2512d244ff6c6ce309", size = 4610255 },
+    { url = "https://files.pythonhosted.org/packages/7b/f9/cfaa5082ca9bc4a6de66ffe1c12c2d90bf09c309a5f52b27759a596900e7/pillow-10.4.0-cp313-cp313-win32.whl", hash = "sha256:551d3fd6e9dc15e4c1eb6fc4ba2b39c0c7933fa113b220057a34f4bb3268a060", size = 2235603 },
+    { url = "https://files.pythonhosted.org/packages/01/6a/30ff0eef6e0c0e71e55ded56a38d4859bf9d3634a94a88743897b5f96936/pillow-10.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:030abdbe43ee02e0de642aee345efa443740aa4d828bfe8e2eb11922ea6a21ea", size = 2554972 },
+    { url = "https://files.pythonhosted.org/packages/48/2c/2e0a52890f269435eee38b21c8218e102c621fe8d8df8b9dd06fabf879ba/pillow-10.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:5b001114dd152cfd6b23befeb28d7aee43553e2402c9f159807bf55f33af8a8d", size = 2243375 },
 ]
 
 [[package]]
@@ -931,6 +1216,19 @@ crypto = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/44/e6de2fdc880ad0ec7547ca2e087212be815efbc9a425a8d5ba9ede602cbb/pymdown_extensions-10.14.3.tar.gz", hash = "sha256:41e576ce3f5d650be59e900e4ceff231e0aed2a88cf30acaee41e02f063a061b", size = 846846 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/f5/b9e2a42aa8f9e34d52d66de87941ecd236570c7ed2e87775ed23bbe4e224/pymdown_extensions-10.14.3-py3-none-any.whl", hash = "sha256:05e0bee73d64b9c71a4ae17c72abc2f700e8bc8403755a00580b49a4e9f189e9", size = 264467 },
+]
+
+[[package]]
 name = "pynacl"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1014,6 +1312,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/8e/da1c6c58f751b70f8ceb1eb25bc25d524e8f14fe16edcce3f4e3ba08629c/pyyaml_env_tag-0.1.tar.gz", hash = "sha256:70092675bda14fdec33b31ba77e7543de9ddc88f2e5b99160396572d11525bdb", size = 5631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/66/bbb1dd374f5c870f59c5bb1db0e18cbe7fa739415a24cbd95b2d1f5ae0c4/pyyaml_env_tag-0.1-py3-none-any.whl", hash = "sha256:af31106dec8a4d68c60207c1886031cbf839b68aa7abccdb19868200532c2069", size = 3911 },
 ]
 
 [[package]]
@@ -1106,6 +1416,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
+name = "tinycss2"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/fd/7a5ee21fd08ff70d3d33a5781c255cbe779659bd03278feb98b19ee550f4/tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7", size = 87085 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289", size = 26610 },
 ]
 
 [[package]]
@@ -1215,6 +1537,39 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/88/dacc875dd54a8acadb4bcbfd4e3e86df8be75527116c91d8f9784f5e9cab/virtualenv-20.29.2.tar.gz", hash = "sha256:fdaabebf6d03b5ba83ae0a02cfe96f48a716f4fae556461d180825866f75b728", size = 4320272 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/fa/849483d56773ae29740ae70043ad88e068f98a6401aa819b5d6bee604683/virtualenv-20.29.2-py3-none-any.whl", hash = "sha256:febddfc3d1ea571bdb1dc0f98d7b45d24def7428214d4fb73cc486c9568cce6a", size = 4301478 },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471 },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449 },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054 },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480 },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451 },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057 },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079 },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076 },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077 },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077 },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065 },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070 },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067 },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Adds documentation and publishes it to GitHub Pages using MkDocs. This includes setting up a documentation workflow, adding documentation files, and configuring MkDocs.

Build:
- Adds mkdocs and related dependencies to pyproject.toml.
- Adds scripts to build and serve the documentation.
- Configures a GitHub Actions workflow to build and deploy the documentation to GitHub Pages.

Documentation:
- Adds documentation files for development, API reference, contributing, configuration, installation, usage, and release notes.
- Configures MkDocs with the Material theme and various plugins.
- Adds custom CSS styles for the documentation.