### PR TITLE
fix(release): set remote URL for pushing changes in workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,6 +74,7 @@ jobs:
       run: |
         git config --global user.name github-actions
         git config --global user.email github-actions@github.com
+        git remote set-url --push origin "https://ruancomelli:${{ secrets.GITHUB_TOKEN }}@github.com/ruancomelli/brag-ai"
 
         git add src/brag/__init__.py
         git add CHANGELOG.md


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Set the remote URL for pushing changes in the release workflow using a GitHub token.