### PR TITLE
fix(release): add PAT to bypass `main` protection rules

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    environment: release
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -74,7 +75,7 @@ jobs:
       run: |
         git config --global user.name ruancomelli
         git config --global user.email 2275292+ruancomelli@users.noreply.github.com
-        git remote set-url --push origin "https://ruancomelli:${{ secrets.GITHUB_TOKEN }}@github.com/ruancomelli/brag-ai"
+        git remote set-url --push origin "https://ruancomelli:${{ secrets.MAIN_BRANCH_PROTECTION_BYPASS_PAT }}@github.com/ruancomelli/brag-ai"
 
         git add src/brag/__init__.py
         git add CHANGELOG.md


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Configures the release job to use a PAT to bypass main branch protection rules.