### PR TITLE
fix(release): use the actor name provided by the `github` environment

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: Publish release to PyPI
 on:
   release:
     types:
-    - created
+    - published
 
 jobs:
   pypi:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,9 +73,9 @@ jobs:
 
     - name: Commit and push version and changelog
       run: |
-        git config --global user.name ruancomelli
-        git config --global user.email 2275292+ruancomelli@users.noreply.github.com
-        git remote set-url --push origin "https://ruancomelli:${{ secrets.MAIN_BRANCH_PROTECTION_BYPASS_PAT }}@github.com/ruancomelli/brag-ai"
+        git config --global user.name ${{ github.actor }}
+        git config --global user.email ${{ github.actor }}@users.noreply.github.com
+        git remote set-url --push origin "https://${{ github.actor }}:${{ secrets.MAIN_BRANCH_PROTECTION_BYPASS_PAT }}@github.com/${{ github.repository }}"
 
         git add src/brag/__init__.py
         git add CHANGELOG.md


### PR DESCRIPTION
## Summary by Sourcery

Fixes the release workflow to correctly use the actor name provided by the github environment. Updates the publish workflow to trigger on published releases instead of created releases.

CI:
- Updates the release workflow to use the actor name provided by the github environment.
- Updates the publish workflow to trigger on published releases instead of created releases.