### PR TITLE
chore: fix project name from `brag` to `brag-ai`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.6.4
+  rev: 0.6.5
   hooks:
       # Update the uv lockfile
   - id: uv-lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 dynamic = ["version"]
 
-name = "brag"
+name = "brag-ai"
 description = "Generate and maintain a brag document automatically from your GitHub contributions, powered by AI."
 
 authors = [{ name = "Ruan Comelli", email = "ruancomelli@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 path = "src/brag/__init__.py"
 
+[tool.hatch.build.targets.wheel]
+packages = ["src/brag"]
+
 [dependency-groups]
 lint = ["ruff>=0.9.7"]
 format = ["ruff>=0.9.7"]

--- a/uv.lock
+++ b/uv.lock
@@ -78,7 +78,7 @@ wheels = [
 ]
 
 [[package]]
-name = "brag"
+name = "brag-ai"
 source = { editable = "." }
 dependencies = [
     { name = "asyncer" },


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Rename the project from `brag` to `brag-ai`.