### PR TITLE
fix(release): remove extra leading `v`s in version tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
           version="${{ github.event.inputs.version }}"
         fi
         # Remove the v prefix from the version
-        echo "version=${version#v}" >> "${GITHUB_OUTPUT}"
+        echo "version=${version//v}" >> "${GITHUB_OUTPUT}"
 
     - name: Update version in __init__.py
       run: |


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Removes extra leading 'v's from the version tag in the release workflow.