### PR TITLE
refactor: replace `typer` with `cryclopts`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,18 +21,16 @@ classifiers = [
 
 requires-python = ">=3.12"
 dependencies = [
-    "asyncer>=0.0.8",
-    "click>=8.1.8",
+    "cyclopts>=3.9.2",
     "loguru>=0.7.3",
     "pydantic>=2.10.6",
     "pydantic-ai>=0.0.24",
     "pygithub>=2.6.0",
     "rich>=13.9.4",
-    "typer>=0.15.1",
 ]
 
 [project.urls]
-# Homepage = "https://example.com"
+Homepage = "https://github.com/ruancomelli/brag-ai"
 Documentation = "https://ruancomelli.github.io/brag-ai/"
 Repository = "https://github.com/ruancomelli/brag-ai.git"
 Issues = "https://github.com/ruancomelli/brag-ai/issues"
@@ -93,6 +91,7 @@ select = [
 ]
 ignore = [
     "D105",    # Missing docstring in magic method
+    "D107",    # Missing docstring in __init__
     "D203",    # incorrect-blank-line-before-class
     "D213",    # multi-line-summary-second-line
     "D413",    # Missing blank line after last section

--- a/src/brag/cli/self.py
+++ b/src/brag/cli/self.py
@@ -1,0 +1,38 @@
+"""The `self` subcommand of the `brag` CLI."""
+
+import subprocess
+import sys
+
+from cyclopts import App
+
+from brag import __version__ as CURRENT_BRAG_VERSION
+
+app = App(
+    name="self",
+    help="Manage the `brag-ai` CLI itself.",
+)
+
+
+@app.command
+def upgrade() -> None:
+    """Update brag to latest stable version."""
+    # Implementation based on the `cyclopts` cookbook example:
+    # https://cyclopts.readthedocs.io/en/latest/cookbook/app_upgrade.html
+
+    old_version = CURRENT_BRAG_VERSION
+
+    subprocess.check_output(
+        (sys.executable, "-m", "pip", "install", "--upgrade", "brag")
+    )
+
+    res = subprocess.run(
+        (sys.executable, "-m", "brag", "--version"),
+        stdout=subprocess.PIPE,
+        check=True,
+    )
+    new_version = res.stdout.decode().strip()
+
+    if old_version != new_version:
+        print(f"`brag-ai` updated from v{old_version} to v{new_version}.")
+    else:
+        print(f"`brag-ai` is already up-to-date (v{new_version}).")

--- a/src/brag/models.py
+++ b/src/brag/models.py
@@ -1,0 +1,69 @@
+"""Model definitions for AI providers and their models.
+
+This module provides a standardized way to represent and work with AI models
+from different providers. It includes utilities for parsing model names,
+validating them, and accessing available models.
+"""
+
+from collections.abc import Iterator
+from typing import Self
+from typing import get_args as get_literal_type_args
+
+from pydantic import BaseModel, ConfigDict
+from pydantic_ai.models import KnownModelName as _KnownModelName
+
+type AvailableModelFullName = _KnownModelName
+type ProviderName = str
+type ModelName = str
+
+
+class InvalidFullModelNameError(ValueError):
+    """Raised when a full model name doesn't follow the 'provider:name' format."""
+
+    def __init__(self, full_name: str) -> None:
+        super().__init__(f"Invalid model name: {full_name}")
+
+
+class Model(BaseModel):
+    """Represents an AI model with its provider and name.
+
+    Models are immutable and identified by a combination of provider and name.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    provider: ProviderName
+    name: ModelName
+
+    @property
+    def full_name(self) -> str:
+        """The full qualified name of the model in 'provider:name' format."""
+        return f"{self.provider}:{self.name}"
+
+    @classmethod
+    def from_full_name(cls, full_name: str) -> Self:
+        """Parse a full model name in 'provider:name' format into a Model instance."""
+        try:
+            provider, name = full_name.split(":")
+        except ValueError as e:
+            raise InvalidFullModelNameError(full_name) from e
+
+        return cls(provider=provider, name=name)
+
+
+def _iter_available_models() -> Iterator[Model]:
+    """Iterate over all available models from pydantic-ai's known models.
+
+    Skips models with invalid provider names.
+    """
+    known_models = get_literal_type_args(AvailableModelFullName)
+    for model_name in known_models:
+        try:
+            yield Model.from_full_name(model_name)
+        except InvalidFullModelNameError:
+            # Some models in `pydantic-ai` don't have a valid provider name
+            continue
+
+
+AVAILABLE_MODELS = frozenset(_iter_available_models())
+"""Frozen set of all available and valid AI models."""

--- a/src/brag/repository.py
+++ b/src/brag/repository.py
@@ -1,8 +1,13 @@
 """Defines a data structure for representing a repository."""
 
-from typing import Self
+from typing import Annotated, Self
 
-from pydantic import BaseModel
+from pydantic import BaseModel, StringConstraints
+
+type RepoFullName = Annotated[
+    str,
+    StringConstraints(pattern=r"^[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+$"),
+]
 
 
 class RepoReference(BaseModel):
@@ -22,17 +27,14 @@ class RepoReference(BaseModel):
         return f"{self.owner}/{self.name}"
 
     @classmethod
-    def from_repo_full_name(cls, repo_full_name: str) -> Self:
-        """Create a RepoReference object from a full repository name string.
+    def from_repo_full_name(cls, repo_full_name: RepoFullName) -> Self:
+        """Create a RepoReference object from a RepoFullName object.
 
         Args:
-            repo_full_name: The full name of the repository in the format 'owner/name'.
+            repo_full_name: A RepoFullName object.
 
         Returns:
             A RepoReference object.
-
-        Raises:
-            ValueError: If the repository full name is not in the correct format.
         """
         owner, name = repo_full_name.split("/")
         return cls(owner=owner, name=name)

--- a/uv.lock
+++ b/uv.lock
@@ -44,15 +44,12 @@ wheels = [
 ]
 
 [[package]]
-name = "asyncer"
-version = "0.0.8"
+name = "attrs"
+version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/67/7ea59c3e69eaeee42e7fc91a5be67ca5849c8979acac2b920249760c6af2/asyncer-0.0.8.tar.gz", hash = "sha256:a589d980f57e20efb07ed91d0dbe67f1d2fd343e7142c66d3a099f05c620739c", size = 18217 }
+sdist = { url = "https://files.pythonhosted.org/packages/49/7c/fdf464bcc51d23881d110abd74b512a42b3d5d376a55a831b44c603ae17f/attrs-25.1.0.tar.gz", hash = "sha256:1c97078a80c814273a76b2a298a932eb681c87415c11dee0a6921de7f1b02c3e", size = 810562 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/04/15b6ca6b7842eda2748bda0a0af73f2d054e9344320f8bba01f994294bcb/asyncer-0.0.8-py3-none-any.whl", hash = "sha256:5920d48fc99c8f8f0f1576e1882f5022885589c5fcbc46ce4224ec3e53776eeb", size = 9209 },
+    { url = "https://files.pythonhosted.org/packages/fc/30/d4986a882011f9df997a55e6becd864812ccfcd821d64aac8570ee39f719/attrs-25.1.0-py3-none-any.whl", hash = "sha256:c75a69e28a550a7e93789579c22aa26b0f5b83b75dc4e08fe092980051e1090a", size = 63152 },
 ]
 
 [[package]]
@@ -81,14 +78,12 @@ wheels = [
 name = "brag-ai"
 source = { editable = "." }
 dependencies = [
-    { name = "asyncer" },
-    { name = "click" },
+    { name = "cyclopts" },
     { name = "loguru" },
     { name = "pydantic" },
     { name = "pydantic-ai" },
     { name = "pygithub" },
     { name = "rich" },
-    { name = "typer" },
 ]
 
 [package.dev-dependencies]
@@ -120,14 +115,12 @@ type-check = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asyncer", specifier = ">=0.0.8" },
-    { name = "click", specifier = ">=8.1.8" },
+    { name = "cyclopts", specifier = ">=3.9.2" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pydantic-ai", specifier = ">=0.0.24" },
     { name = "pygithub", specifier = ">=2.6.0" },
     { name = "rich", specifier = ">=13.9.4" },
-    { name = "typer", specifier = ">=0.15.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -399,6 +392,21 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "3.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser", marker = "python_full_version < '4.0'" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/49/0c04eeb72c2e1f9c47ceeb12b174154ec13e32121152da591fbbcb653dba/cyclopts-3.9.2.tar.gz", hash = "sha256:5295db5f4e47b04292c2e6c7cb958c788db61e5d7cce6176bb25b5598f0867c2", size = 67260 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/e4/3e4ad0a7bb04c1b2196f84fa527b6aabf40b66dc4b66f6456d22f941c90b/cyclopts-3.9.2-py3-none-any.whl", hash = "sha256:7627e2a30f354f208df50edb68a806055cdb46f34d7d5a0cfe24780f2b71ef25", size = 76995 },
+]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -435,6 +443,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277 },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/12/9c22a58c0b1e29271051222d8906257616da84135af9ed167c9e28f85cb3/docstring_parser-0.16.tar.gz", hash = "sha256:538beabd0af1e2db0146b6bd3caa526c35a34d61af9fd2887f3a8a27a739aa6e", size = 26565 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/7c/e9fcff7623954d86bdc17782036cbf715ecab1bec4847c008557affe1ca8/docstring_parser-0.16-py3-none-any.whl", hash = "sha256:bf0a1387354d3691d102edef7ec124f219ef639982d096e26e3b60aeffa90637", size = 36533 },
+]
+
+[[package]]
+name = "docutils"
+version = "0.21.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408 },
 ]
 
 [[package]]
@@ -1416,6 +1442,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich-rst"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/69/5514c3a87b5f10f09a34bb011bc0927bc12c596c8dae5915604e71abc386/rich_rst-1.3.1.tar.gz", hash = "sha256:fad46e3ba42785ea8c1785e2ceaa56e0ffa32dbe5410dec432f37e4107c4f383", size = 13839 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/bc/cc4e3dbc5e7992398dcb7a8eda0cbcf4fb792a0cdb93f857b478bf3cf884/rich_rst-1.3.1-py3-none-any.whl", hash = "sha256:498a74e3896507ab04492d326e794c3ef76e7cda078703aa592d1853d91098c1", size = 11621 },
+]
+
+[[package]]
 name = "rsa"
 version = "4.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1450,15 +1489,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/79/acbc1edd03ac0e2a04ae2593555dbc9990b34090a9729a0c4c0cf20fb595/ruff-0.9.7-py3-none-win32.whl", hash = "sha256:e9ece95b7de5923cbf38893f066ed2872be2f2f477ba94f826c8defdd6ec6b7d", size = 9988751 },
     { url = "https://files.pythonhosted.org/packages/6d/95/67153a838c6b6ba7a2401241fd8a00cd8c627a8e4a0491b8d853dedeffe0/ruff-0.9.7-py3-none-win_amd64.whl", hash = "sha256:3770fe52b9d691a15f0b87ada29c45324b2ace8f01200fb0c14845e499eb0c2c", size = 11002987 },
     { url = "https://files.pythonhosted.org/packages/63/6a/aca01554949f3a401991dc32fe22837baeaccb8a0d868256cbb26a029778/ruff-0.9.7-py3-none-win_arm64.whl", hash = "sha256:b075a700b2533feb7a01130ff656a4ec0d5f340bb540ad98759b8401c32c2037", size = 10177763 },
-]
-
-[[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755 },
 ]
 
 [[package]]
@@ -1526,21 +1556,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540 },
-]
-
-[[package]]
-name = "typer"
-version = "0.15.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/dca7b219718afd37a0068f4f2530a727c2b74a8b6e8e0c0080a4c0de4fcd/typer-0.15.1.tar.gz", hash = "sha256:a0588c0a7fa68a1978a069818657778f86abe6ff5ea6abf472f940a08bfe4f0a", size = 99789 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/cc/0a838ba5ca64dc832aa43f727bd586309846b0ffb2ce52422543e6075e8a/typer-0.15.1-py3-none-any.whl", hash = "sha256:7994fb7b8155b64d3402518560648446072864beefd44aa2dc36972a5972e847", size = 44908 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Refactors the CLI to use `cyclopts` instead of `typer`. This change provides a more flexible and feature-rich CLI experience, including improved configuration and subcommands. It also adds a `self upgrade` subcommand to update the CLI to the latest version and a `list-models` subcommand to list all available models.

Enhancements:
- Replaces `typer` with `cyclopts` for CLI argument parsing.
- Adds a `self upgrade` subcommand to update the CLI to the latest version.
- Adds a `list-models` subcommand to list all available models.
- Improves CLI configuration using `cyclopts` configuration options.
- Adds groups to the CLI arguments to improve the help output.
- Replaces `pydantic-ai.models.KnownModelName` with a custom `AvailableModelFullName` type to allow for more flexibility in the future.
- Adds validation to the `repo` argument to ensure it is in the correct format.
- Removes the `asyncer` dependency.
- Removes the `click` dependency.
- Updates the `RepoReference` class to use a `RepoFullName` type for the `repo_full_name` argument.
- Adds a `__version__` variable to the `brag` package and uses it to display the version in the CLI.
- Adds a homepage URL to the `pyproject.toml` file.
- Adds a new `models.py` file to define the `Model` class and related types.
- Moves the CLI entrypoint to the `brag.cli` package.
- Adds a new `self.py` file to define the `self` subcommand.
- Removes the `rich_markup_mode` and `no_args_is_help` options from the `Typer` constructor.
- Replaces `BadParameter` exception with `ValueError` exception.
- Removes the workaround for `typer` not supporting `Literal` types.
- Removes the `envvar` argument from the `github_api_token` option.
- Removes the `click_type` argument from the `model_name` option.
- Removes the `runnify` decorator from the `from_repo` function.
- Removes the `Argument` and `Option` classes from `typer` and replaces them with `cyclopts.Parameter`.
- Removes the `Typer` class from `typer` and replaces it with `cyclopts.App`.
- Removes the `typer` dependency from the `pyproject.toml` file.
- Removes the `asyncer` dependency from the `pyproject.toml` file.
- Removes the `click` dependency from the `pyproject.toml` file.
- Updates the `RepoReference` class to use a `RepoFullName` type for the `from_repo_full_name` method.
- Updates the `from_repo` function to use the `RepoFullName` type for the `repo_full_name` argument.
- Updates the `from_repo` function to use the `AvailableModelFullName` type for the `model_name` argument.
- Updates the `from_repo` function to use the `datetime` type for the `from_date` and `to_date` arguments.
- Updates the `from_repo` function to use the `Path` type for the `output` argument.
- Updates the `from_repo` function to use the `bool` type for the `overwrite` argument.
- Updates the `from_repo` function to use the `str` type for the `language` argument.
- Updates the `from_repo` function to use the `int` type for the `limit` argument.
- Updates the `from_repo` function to use the `str` type for the `github_api_token` argument.
- Updates the `from_repo` function to use the `str` type for the `user_login` argument.