### PR TITLE
feat: accept full GitHub URLs in addition to `owner/repo` strings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,7 +69,7 @@ Brag AI has several command-line options that can be used to configure its behav
 
 ## Model Selection
 
-Brag AI supports a variety of AI models through `pydantic-ai`. You can specify which model to use with the `--model` option.
+Brag AI supports a variety of AI models through PydanticAI. You can specify which model to use with the `--model` option.
 
 The format for the model name is `provider:model-name`. For example:
 
@@ -77,18 +77,18 @@ The format for the model name is `provider:model-name`. For example:
 - `anthropic:claude-3-5-sonnet-latest`
 - `google-vertex:gemini-2.0-flash`
 
-For a full list of supported models, see the [pydantic-ai documentation](https://ai.pydantic.dev/models/).
+For a full list of supported models, see the [PydanticAI documentation](https://ai.pydantic.dev/models/).
 
 ## Default Values
 
 If not specified, Brag AI uses the following default values:
 
-- User: The owner of the GitHub API token
+- User: The owner of the GitHub API token, if provided
 - From date: None (no lower bound)
 - To date: None (the current date)
 - Limit: None (no limit)
 - Output: stdout (print to console)
-- Model: The default model configured in pydantic-ai
+- Model: `google-gla:gemini-2.0-flash`
 - Language: English
 
 ## Example Configurations

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,13 +4,19 @@ Brag AI is designed to be simple to use while providing powerful functionality. 
 
 ## Basic Usage
 
-The most basic way to use Brag AI is to generate a brag document from a GitHub repository:
+The primary use case is to generate a brag document for your contributions to a specific GitHub repository:
 
 ```bash
-brag from-repo owner/repo --user github-username
+brag from-repo my-org/my-repo --user my-username
 ```
 
-This will generate a brag document based on the commits made by `github-username` to the specified repository.
+You can also specify a GitHub repository using its URL:
+
+```bash
+brag from-repo https://github.com/my-org/my-repo --user my-username
+```
+
+This is convenient when copying a repository URL directly from a browser.
 
 ## Command Line Options
 
@@ -18,6 +24,7 @@ Brag AI offers several command line options to customize the generated brag docu
 
 | Option               | Description                                                                                                             |
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `--repo`             | The repository to generate the brag document for. Can be in `owner/repo` format or a GitHub URL.                        |
 | `--user`             | The GitHub username to generate the brag document for. If not provided, the owner of the GitHub API token will be used. |
 | `--from`             | The start date to generate the brag document for (format: YYYY-MM-DD).                                                  |
 | `--to`               | The end date to generate the brag document for (format: YYYY-MM-DD).                                                    |
@@ -76,6 +83,13 @@ Brag AI supports various AI models through `pydantic-ai`. You can specify which 
 ```bash
 export OPENAI_API_KEY=your-openai-api-key
 brag from-repo owner/repo --model openai:gpt-4o --user github-username
+```
+
+Or using a GitHub URL:
+
+```bash
+export OPENAI_API_KEY=your-openai-api-key
+brag from-repo https://github.com/owner/repo --model openai:gpt-4o --user github-username
 ```
 
 ### Anthropic Models

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -76,20 +76,13 @@ This combines multiple options to generate a brag document in Portuguese for a s
 
 ## Using Different AI Models
 
-Brag AI supports various AI models through `pydantic-ai`. You can specify which model to use with the `--model` option:
+Brag AI supports various AI models through [PydanticAI](https://ai.pydantic.dev/models/). You can specify which model to use with the `--model` option:
 
 ### OpenAI Models
 
 ```bash
 export OPENAI_API_KEY=your-openai-api-key
 brag from-repo owner/repo --model openai:gpt-4o --user github-username
-```
-
-Or using a GitHub URL:
-
-```bash
-export OPENAI_API_KEY=your-openai-api-key
-brag from-repo https://github.com/owner/repo --model openai:gpt-4o --user github-username
 ```
 
 ### Anthropic Models

--- a/src/brag/repository.py
+++ b/src/brag/repository.py
@@ -9,6 +9,13 @@ type RepoFullName = Annotated[
     StringConstraints(pattern=r"^[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+$"),
 ]
 
+type GitHubRepoURL = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^https?://github\.com/[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+(?:\.git)?$"
+    ),
+]
+
 
 class RepoReference(BaseModel):
     """A reference to a repository on a code hosting platform.
@@ -38,3 +45,20 @@ class RepoReference(BaseModel):
         """
         owner, name = repo_full_name.split("/")
         return cls(owner=owner, name=name)
+
+    @classmethod
+    def from_github_repo_url(cls, github_repo_url: GitHubRepoURL) -> Self:
+        """Create a RepoReference object from a GitHub repository URL.
+
+        Args:
+            github_repo_url: A GitHub repository URL.
+
+        Returns:
+            A RepoReference object.
+        """
+        repo_full_name = (
+            github_repo_url.removesuffix(".git")
+            .removeprefix("https://github.com/")
+            .removeprefix("http://github.com/")
+        )
+        return cls.from_repo_full_name(repo_full_name)

--- a/tests/brag/test_repository.py
+++ b/tests/brag/test_repository.py
@@ -2,7 +2,13 @@
 
 import pytest
 
-from brag.repository import RepoReference
+from brag.repository import (
+    REPO_FULL_NAME_PATTERN,
+    REPO_URL_PATTERN,
+    InvalidGitHubRepoURL,
+    InvalidRepoFullName,
+    RepoReference,
+)
 
 
 def test_repo_reference_creation() -> None:
@@ -39,8 +45,11 @@ def test_from_repo_full_name(
 
 def test_from_repo_full_name_raises_value_error() -> None:
     """Test that from_repo_full_name raises a ValueError for invalid input."""
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidRepoFullName) as e:
         RepoReference.from_repo_full_name("invalid-repo-name")
+    assert "Invalid repository full name: 'invalid-repo-name'" in str(e.value)
+    assert e.value.repo_full_name == "invalid-repo-name"
+    assert e.value.expected_format == REPO_FULL_NAME_PATTERN
 
 
 @pytest.mark.parametrize(
@@ -73,5 +82,8 @@ def test_from_github_repo_url(
 )
 def test_from_github_repo_url_raises_value_error(invalid_url: str) -> None:
     """Test that from_github_repo_url raises a ValueError for invalid input."""
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidGitHubRepoURL) as e:
         RepoReference.from_github_repo_url(invalid_url)
+    assert f"Invalid GitHub repository URL: {invalid_url!r}" in str(e.value)
+    assert e.value.github_repo_url == invalid_url
+    assert e.value.expected_format == REPO_URL_PATTERN

--- a/tests/brag/test_repository.py
+++ b/tests/brag/test_repository.py
@@ -19,11 +19,11 @@ def test_repo_reference_full_name() -> None:
 
 
 @pytest.mark.parametrize(
-    "repo_full_name, expected_owner, expected_name",
-    [
+    ("repo_full_name", "expected_owner", "expected_name"),
+    (
         ("owner1/repo1", "owner1", "repo1"),
         ("owner2/repo2", "owner2", "repo2"),
-    ],
+    ),
 )
 def test_from_repo_full_name(
     repo_full_name: str,
@@ -41,3 +41,37 @@ def test_from_repo_full_name_raises_value_error() -> None:
     """Test that from_repo_full_name raises a ValueError for invalid input."""
     with pytest.raises(ValueError):
         RepoReference.from_repo_full_name("invalid-repo-name")
+
+
+@pytest.mark.parametrize(
+    ("github_repo_url", "expected_owner", "expected_name"),
+    (
+        ("https://github.com/owner1/repo1", "owner1", "repo1"),
+        ("http://github.com/owner2/repo2", "owner2", "repo2"),
+        ("https://github.com/owner3/repo3.git", "owner3", "repo3"),
+    ),
+)
+def test_from_github_repo_url(
+    github_repo_url: str,
+    expected_owner: str,
+    expected_name: str,
+) -> None:
+    """Test creating a RepoReference from a GitHub repository URL."""
+    repo = RepoReference.from_github_repo_url(github_repo_url)
+    assert repo.owner == expected_owner
+    assert repo.name == expected_name
+    assert repo.full_name == f"{expected_owner}/{expected_name}"
+
+
+@pytest.mark.parametrize(
+    "invalid_url",
+    (
+        "https://gitlab.com/owner/repo",
+        "github.com/owner/repo",
+        "https://github.com/owner",
+    ),
+)
+def test_from_github_repo_url_raises_value_error(invalid_url: str) -> None:
+    """Test that from_github_repo_url raises a ValueError for invalid input."""
+    with pytest.raises(ValueError):
+        RepoReference.from_github_repo_url(invalid_url)


### PR DESCRIPTION
## Summary by Sourcery

Allow the CLI to accept full GitHub URLs in addition to `owner/repo` strings when specifying a repository. Update uv pre-commit hook.

New Features:
- Allow the CLI to accept full GitHub URLs when specifying a repository.

Tests:
- Add tests for the new feature of accepting full GitHub URLs when specifying a repository.