### PR TITLE
fix(cli/self): install the `brag-ai` project instead of trying to install `brag`

### DIFF
--- a/src/brag/cli/self.py
+++ b/src/brag/cli/self.py
@@ -25,12 +25,18 @@ def upgrade() -> None:
         (sys.executable, "-m", "pip", "install", "--upgrade", "brag-ai")
     )
 
-    res = subprocess.run(
-        (sys.executable, "-m", "brag", "--version"),
-        stdout=subprocess.PIPE,
-        check=True,
+    new_version = (
+        subprocess.check_output(
+            (
+                sys.executable,
+                "-m",
+                "brag",
+                "--version",
+            )
+        )
+        .decode()
+        .strip()
     )
-    new_version = res.stdout.decode().strip()
 
     if old_version != new_version:
         print(f"`brag-ai` updated from v{old_version} to v{new_version}.")

--- a/src/brag/cli/self.py
+++ b/src/brag/cli/self.py
@@ -22,7 +22,7 @@ def upgrade() -> None:
     old_version = CURRENT_BRAG_VERSION
 
     subprocess.check_output(
-        (sys.executable, "-m", "pip", "install", "--upgrade", "brag")
+        (sys.executable, "-m", "pip", "install", "--upgrade", "brag-ai")
     )
 
     res = subprocess.run(


### PR DESCRIPTION
fix(cli/self): install the `brag-ai` project instead of trying to install `brag`

refactor(cli/self): use `subprocess.check_output` instead of `subprocess.run`

## Summary by Sourcery

Fixes an issue where the CLI was trying to install the `brag` package instead of `brag-ai` when upgrading. Uses `subprocess.check_output` instead of `subprocess.run` to get the new version.

Bug Fixes:
- Fixes an issue where the CLI was trying to install the `brag` package instead of `brag-ai` when upgrading. 

Enhancements:
- Uses `subprocess.check_output` instead of `subprocess.run` to get the new version.