### PR TITLE
ci: publish project to PyPI in the same job that we release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,9 +13,11 @@ on:
 
 jobs:
   release:
+    name: Release and publish to PyPI
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     environment: release
     steps:
     - name: Checkout
@@ -94,26 +96,8 @@ jobs:
         body: ${{ steps.generate-release-changelog.outputs.content }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
-  publish-pypi:
-    name: Publish to PyPI
-    needs: release
-    runs-on: ubuntu-latest
-    environment:
-      name: release
-    permissions:
-      id-token: write
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        persist-credentials: false
-    - uses: astral-sh/setup-uv@v5
-      with:
-        enable-cache: false
     - name: Build package
       run: uv build
-        # Check that basic features work and we didn't miss to include crucial files
-        # - name: Smoke test (wheel)
-        #   run: uv run --isolated --no-project -p 3.13 --with dist/*.whl tests/smoke_test.py
-        # - name: Smoke test (source distribution)
-        #   run: uv run --isolated --no-project -p 3.13 --with dist/*.tar.gz tests/smoke_test.py
-    - run: uv publish --trusted-publishing always
+
+    - name: Publish to PyPI
+      run: uv publish --trusted-publishing always

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.6.5
+  rev: 0.6.6
   hooks:
       # Update the uv lockfile
   - id: uv-lock


### PR DESCRIPTION
This allows the publish step to re-use the permissions
given to the release step, namely the admin's authorization
to run jobs in the `release` environment.

## Summary by Sourcery

Consolidates the release and PyPI publishing jobs into a single job to reuse permissions, and updates the uv-pre-commit hook version.

CI:
- Combines the release and PyPI publishing jobs into a single job within the CI workflow to streamline the release process.
- Updates the uv-pre-commit hook version to 0.6.6 in .pre-commit-config.yaml file.