### PR TITLE
docs(README): include `.git` suffix in the link to the repository

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.6.6
+  rev: 0.6.9
   hooks:
       # Update the uv lockfile
   - id: uv-lock

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This project is licensed under the [GNU General Public License v3.0](https://cho
 - 📖 [Documentation](https://ruancomelli.github.io/brag-ai/)
 - 🐛 [Issue Tracker](https://github.com/ruancomelli/brag-ai/issues)
 - 💬 [Discussions](https://github.com/ruancomelli/brag-ai/discussions)
-- 💻 [Repository](https://github.com/ruancomelli/brag-ai)
+- 💻 [Repository](https://github.com/ruancomelli/brag-ai.git)
 
 ## Why Brag AI?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.pydocstyle]
-ignore-decorators = ["typing.overload", "ropeskip._typing.override"]
+ignore-decorators = ["typing.overload"]
 
 [tool.codeflash]
 # All paths are relative to this pyproject.toml's directory.


### PR DESCRIPTION
## Summary by Sourcery

Update the repository link in the README to include the `.git` suffix, update the `uv-pre-commit` hook revision, and remove `ropeskip._typing.override` from the ignored decorators in `pyproject.toml`.

Chores:
- Update the repository link in the README to include the `.git` suffix.
- Update the `uv-pre-commit` hook revision.
- Remove `ropeskip._typing.override` from the ignored decorators in `pyproject.toml`.