### PR TITLE
ci: disable `pre-commit-check` in CI checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,8 +20,11 @@ jobs:
           run: bash scripts/format.sh
         - name: type-check
           run: bash scripts/type-check.sh
-        - name: pre-commit
-          run: bash scripts/pre-commit-check.sh
+        # Disabled pre-commit checks since they are flaky
+        # and unhelpful - see e.g.
+        # https://github.com/ruancomelli/brag-ai/actions/runs/14008479153/job/39225367619
+        # - name: pre-commit
+        #   run: bash scripts/pre-commit-check.sh
 
     name: Python ${{ matrix.check.name }}
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.6.6
+  rev: 0.6.9
   hooks:
       # Update the uv lockfile
   - id: uv-lock


### PR DESCRIPTION
## Summary by Sourcery

Disable the pre-commit checks in CI due to flakiness and unhelpfulness. Update the uv-pre-commit hook to rev 0.6.9.

CI:
- Disable pre-commit checks in CI.
- Update the uv-pre-commit hook to rev 0.6.9.