### PR TITLE
ci: bump `uv-pre-commit` version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.6.9
+  rev: 0.6.13
   hooks:
       # Update the uv lockfile
   - id: uv-lock


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Bump uv-pre-commit hook from version 0.6.9 to 0.6.13