### PR TITLE
docs: fix copyright year to be 2025

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,4 +124,4 @@ extra:
     link: https://github.com/ruancomelli/brag-ai
     name: ruancomelli/brag-ai on GitHub
 
-copyright: '&copy; 2024 Ruan Comelli'
+copyright: '&copy; 2025 Ruan Comelli'


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update the copyright year in the MkDocs configuration file to reflect the current year