### PR TITLE
docs(README): remove commented-out license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # 💁 Brag AI
 
-<!-- [![License](https://img.shields.io/pypi/l/brag-ai.svg?color=green)](https://github.com/ruancomelli/brag-ai/raw/main/LICENSE) -->
-
 [![PyPI](https://img.shields.io/pypi/v/brag-ai.svg?logo=pypi&logoColor=white)](https://pypi.org/project/brag-ai)
 [![Python Version](https://img.shields.io/pypi/pyversions/brag-ai.svg?logo=python&logoColor=yellow)](https://python.org)
 [![Docs](https://img.shields.io/badge/docs-latest-blue)](https://ruancomelli.github.io/brag-ai/)


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Clean up README by removing an unused commented-out license badge