### PR TITLE
ci: only run `semantic-pull-request-title` workflow when the PR title changes

### DIFF
--- a/.github/workflows/semantic-pull-request-title.yaml
+++ b/.github/workflows/semantic-pull-request-title.yaml
@@ -5,7 +5,6 @@ on:
     types:
     - opened
     - edited
-    - synchronize
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Limit the semantic-pull-request-title workflow to opened and edited PR events, removing the synchronize trigger to prevent runs on new commits.