### PR TITLE
chore: add official support for Python 3.14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,7 @@ jobs:
         python-version:
         - '3.12'
         - '3.13'
+        - '3.14'
         runner:
         - ubuntu-latest
         - macos-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed"
 ]
 requires-python = ">=3.12"

--- a/src/brag/agents.py
+++ b/src/brag/agents.py
@@ -40,7 +40,7 @@ async def generate_brag_document(
         chunks: An iterable of strings, where each string is a chunk of text
             representing a contribution or achievement. This is expected to contain at
             least one chunk.
-        language: The language in which to generate the brag document.
+        language: The human language in which to generate the brag document.
         input_brag_document: An optional existing brag document to update with new
             contributions. If provided, the function will update this document.
             Otherwise, a new document will be generated from scratch.


### PR DESCRIPTION
## Summary by Sourcery

Add official support for Python 3.14 across the project by updating Docker, CI, packaging metadata, and docstrings.

Enhancements:
- Clarify the docstring description for the language parameter to specify it as a human language

Build:
- Update Dockerfile base image to python:3.14-slim

CI:
- Include Python 3.14 in the GitHub Actions CI test matrix

Documentation:
- Add "Programming Language :: Python :: 3.14" classifier in pyproject.toml