### PR TITLE
ci: replace `pre-commit` with `prek`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,10 @@ repos:
   - id: check-toml
   - id: check-xml
   - id: check-yaml
+  - id: debug-statements
   - id: end-of-file-fixer
+  - id: name-tests-test
+    args: [--pytest-test-first]
   - id: no-commit-to-branch
     args: [--branch, main]
   - id: pretty-format-json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ format = ["ruff>=0.9.7"]
 type-check = ["mypy>=1.15.0", "types-dateparser>=1.2.2.20250809"]
 test = ["pytest>=8.3.4"]
 test-cov = ["pytest>=8.3.4", "pytest-cov>=6.0.0"]
-pre-commit = ["deptry>=0.23.0", "pre-commit>=4.1.0"]
+pre-commit = ["deptry>=0.23.0", "prek>=0.2.9"]
 docs = [
     "mkdocs>=1.6.1",
     "mkdocs-api-autonav>=0.2.1",

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 uv sync --all-groups
-uv run --group pre-commit pre-commit install
+uv run --group pre-commit prek install --install-hooks

--- a/scripts/pre-commit-check.sh
+++ b/scripts/pre-commit-check.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-uv run --group pre-commit pre-commit run --all-files --show-diff-on-failure
+uv run --group pre-commit prek run --all-files --show-diff-on-failure

--- a/uv.lock
+++ b/uv.lock
@@ -104,7 +104,7 @@ lint = [
 ]
 pre-commit = [
     { name = "deptry" },
-    { name = "pre-commit" },
+    { name = "prek" },
 ]
 test = [
     { name = "pytest" },
@@ -141,7 +141,7 @@ format = [{ name = "ruff", specifier = ">=0.9.7" }]
 lint = [{ name = "ruff", specifier = ">=0.9.7" }]
 pre-commit = [
     { name = "deptry", specifier = ">=0.23.0" },
-    { name = "pre-commit", specifier = ">=4.1.0" },
+    { name = "prek", specifier = ">=0.2.9" },
 ]
 test = [{ name = "pytest", specifier = ">=8.3.4" }]
 test-cov = [
@@ -230,15 +230,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469, upload-time = "2024-09-04T20:44:41.616Z" },
     { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475, upload-time = "2024-09-04T20:44:43.733Z" },
     { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009, upload-time = "2024-09-04T20:44:45.309Z" },
-]
-
-[[package]]
-name = "cfgv"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
 ]
 
 [[package]]
@@ -478,15 +469,6 @@ wheels = [
 ]
 
 [[package]]
-name = "distlib"
-version = "0.3.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923, upload-time = "2024-10-09T18:35:47.551Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973, upload-time = "2024-10-09T18:35:44.272Z" },
-]
-
-[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -714,15 +696,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e5/f9/851f34b02970e8143d41d4001b2d49e54ef113f273902103823b8bc95ada/huggingface_hub-0.29.3.tar.gz", hash = "sha256:64519a25716e0ba382ba2d3fb3ca082e7c7eb4a2fc634d200e8380006e0760e5", size = 390123, upload-time = "2025-03-11T10:49:40.503Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/0c/37d380846a2e5c9a3c6a73d26ffbcfdcad5fc3eacf42fdf7cff56f2af634/huggingface_hub-0.29.3-py3-none-any.whl", hash = "sha256:0b25710932ac649c08cdbefa6c6ccb8e88eef82927cacdb048efb726429453aa", size = 468997, upload-time = "2025-03-11T10:49:38.674Z" },
-]
-
-[[package]]
-name = "identify"
-version = "2.6.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9b/98/a71ab060daec766acc30fb47dfca219d03de34a70d616a79a38c6066c5bf/identify-2.6.9.tar.gz", hash = "sha256:d40dfe3142a1421d8518e3d3985ef5ac42890683e32306ad614a29490abeb6bf", size = 99249, upload-time = "2025-03-08T15:54:13.632Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/ce/0845144ed1f0e25db5e7a79c2354c1da4b5ce392b8966449d5db8dca18f1/identify-2.6.9-py2.py3-none-any.whl", hash = "sha256:c98b4322da415a8e5a70ff6e51fbc2d2932c015532d77e9f8537b4ba7813b150", size = 99101, upload-time = "2025-03-08T15:54:12.026Z" },
 ]
 
 [[package]]
@@ -1109,15 +1082,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.9.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
-]
-
-[[package]]
 name = "openai"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1225,19 +1189,29 @@ wheels = [
 ]
 
 [[package]]
-name = "pre-commit"
-version = "4.2.0"
+name = "prek"
+version = "0.2.9"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cfgv" },
-    { name = "identify" },
-    { name = "nodeenv" },
-    { name = "pyyaml" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/08/39/679ca9b26c7bb2999ff122d50faa301e49af82ca9c066ec061cfbc0c6784/pre_commit-4.2.0.tar.gz", hash = "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146", size = 193424, upload-time = "2025-03-18T21:35:20.987Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/8c/48e3909945af7b9995e15746afe1f833c1b4b3ca4edd3bc3fe08e4198bf9/prek-0.2.9.tar.gz", hash = "sha256:3866caab6e1031ca12bc65259e20bce4cd479b1c2fd66770ca57b7ca5e9c7687", size = 3020434, upload-time = "2025-10-16T10:56:23.994Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/74/a88bf1b1efeae488a0c0b7bdf71429c313722d1fc0f377537fbe554e6180/pre_commit-4.2.0-py2.py3-none-any.whl", hash = "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd", size = 220707, upload-time = "2025-03-18T21:35:19.343Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/0a/7f3288262fa3c6334fcc62fdd6b01cc3acd351bc8a0e411bf05b4098c88a/prek-0.2.9-py3-none-linux_armv6l.whl", hash = "sha256:602cb546ca7ca1da5f18d4b4fc952cee8498c4212270800220434ddac600f86c", size = 4405977, upload-time = "2025-10-16T10:55:55.95Z" },
+    { url = "https://files.pythonhosted.org/packages/20/37/89f403dde9450719024fe2d57b31002da0dceab4aefb293a58c33a697a04/prek-0.2.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:872797f4eadca9005ef546b4e7c98aeea486dc76ba0c6eee2ba2d53e1221cae5", size = 4505049, upload-time = "2025-10-16T10:55:57.976Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c7/c909407296e7d8ed473225ea6ab892402a45c0d69f890074ab4c9373a2a7/prek-0.2.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c93e8ef1b5a23e1503a162edf3759cd30bb962215fff7db180031892a1b4ceb8", size = 4199383, upload-time = "2025-10-16T10:55:59.606Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/91/1a35bba62a5805b7e474f5e4dae91c90a10108f15f25d7a87528f3fc74b9/prek-0.2.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:5c40f6029039c9576801000ceec91811718997b2299ea7ac1af34d4e2b5a5e82", size = 4385418, upload-time = "2025-10-16T10:56:01.41Z" },
+    { url = "https://files.pythonhosted.org/packages/60/41/7b6553c334335ec60af725ac381d309b6f738042885b87301981ae2b9db4/prek-0.2.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7656870808d3e40747887cf9b1a6598ee5605a0e7f75eb306b5d28124b9a4fa2", size = 4336491, upload-time = "2025-10-16T10:56:03.351Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/99/345a81d35b37acf0c062662455c287300ac4b6ee0c5633a4362506622576/prek-0.2.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:60afd40cf3c8e85118955292a6f9317bcfdb90dee7192a30c7b5e1944c3a4bf7", size = 4618638, upload-time = "2025-10-16T10:56:04.656Z" },
+    { url = "https://files.pythonhosted.org/packages/da/c4/09600215ae417dff7059a56684a751270afbc08b133bb84c44e3fe13b5b6/prek-0.2.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:af9e5a41d39a957a98fac06149321bbbeddde058495bb3235067636c71ac54b6", size = 5060073, upload-time = "2025-10-16T10:56:06.118Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b4/0d04cade1d26fac8b27337ae4a698a783d79205a586ae9a53fc413dc631d/prek-0.2.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:58907cc49afff34e7684063b221bd87820540fb860dc1d2ace0339d96ec2cc2f", size = 4986939, upload-time = "2025-10-16T10:56:07.503Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/36/1dff5a91c45e06df2eef22c3a197bcd1a46eefd4e12bc723ef76dd33f8be/prek-0.2.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e93e63d43cd462c7cfaeecefff6b50f9bed87532db5f95cdf07109ce22b0d82c", size = 5103873, upload-time = "2025-10-16T10:56:08.87Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/81/f12d4c17845d10165c6a53494591c849da4c057cabd21238536073943691/prek-0.2.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b0172dcca93f92d783342ed448eff6808857265d7a269c2f71ab3a0a9cc816c", size = 4688657, upload-time = "2025-10-16T10:56:10.731Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/0e/4fd723183a5bb7d5e9f2303ca92558b80aec4fcb7685b2f616bdb9525bf5/prek-0.2.9-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:c279ec142317fe27cad4bab9a1d5bcdc4d0e77688fb3625effee1a57a73e2737", size = 4395467, upload-time = "2025-10-16T10:56:12.643Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/9a/befaef47e5802fdde3eff6e24426f79e41513bf63780ac382697d5cb4bca/prek-0.2.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:eaf1e9ec46fe6bec190c10ab8040b6e1623a94a6643a2cddf18939cf742c12a8", size = 4499445, upload-time = "2025-10-16T10:56:14.351Z" },
+    { url = "https://files.pythonhosted.org/packages/20/07/e7a0da0beb91cc5d6de304cb6409618d30242ede7ef2d956a80ebd6791cf/prek-0.2.9-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:c0942d6949adc0c47ad4311e42efeafa35d27ce1ee969d65d2148acc654f5ef2", size = 4323381, upload-time = "2025-10-16T10:56:15.696Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e2/40c17b3e760d9760f3b22783ca880e6c1ac46aa6200d476be5ca81fc57a4/prek-0.2.9-py3-none-musllinux_1_1_i686.whl", hash = "sha256:6bc45321b83dab238cc2867bd3a6a7a604079af416d4772500e5956e61c4306e", size = 4513723, upload-time = "2025-10-16T10:56:17.084Z" },
+    { url = "https://files.pythonhosted.org/packages/87/df/243ab98b16e004a4602e19923f0b0b404de871c64cc4e49d32fc60c7cefc/prek-0.2.9-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:e97cb737912844d89f12f2ea724007c2886d73c90e1d9be1133e4da55f872e8c", size = 4791957, upload-time = "2025-10-16T10:56:18.574Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/27/975bcecc1b52bc7c456e9c174a07f8466833893d877183efc4b809035d77/prek-0.2.9-py3-none-win32.whl", hash = "sha256:7d68a2a8a8b2187ef51bb1abe822b2331459021174bad4be53fc1a583dc6d462", size = 4226511, upload-time = "2025-10-16T10:56:19.901Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b2/95571c04bb395e4749510e676111dfb74b5c65a5cba252d155f3017e407b/prek-0.2.9-py3-none-win_amd64.whl", hash = "sha256:40761199f945ba8e171654e2ed5135e04bd2baf20c2a2cc5235c4a672b65aaf2", size = 4799662, upload-time = "2025-10-16T10:56:21.284Z" },
+    { url = "https://files.pythonhosted.org/packages/11/76/80c2dbb5c38a909cdbb5f591401bb882ec2b325641c56163bc62db5a8605/prek-0.2.9-py3-none-win_arm64.whl", hash = "sha256:02e9f38b3bc972bce141e74bcb6f8e3336732031db931fd8d20730c74f20e051", size = 4478662, upload-time = "2025-10-16T10:56:22.734Z" },
 ]
 
 [[package]]
@@ -1873,20 +1847,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268, upload-time = "2024-12-22T07:47:30.032Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369, upload-time = "2024-12-22T07:47:28.074Z" },
-]
-
-[[package]]
-name = "virtualenv"
-version = "20.29.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "distlib" },
-    { name = "filelock" },
-    { name = "platformdirs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/9c/57d19fa093bcf5ac61a48087dd44d00655f85421d1aa9722f8befbf3f40a/virtualenv-20.29.3.tar.gz", hash = "sha256:95e39403fcf3940ac45bc717597dba16110b74506131845d9b687d5e73d947ac", size = 4320280, upload-time = "2025-03-06T19:54:19.055Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/eb/c6db6e3001d58c6a9e67c74bb7b4206767caa3ccc28c6b9eaf4c23fb4e34/virtualenv-20.29.3-py3-none-any.whl", hash = "sha256:3e3d00f5807e83b234dfb6122bf37cfadf4be216c53a49ac059d02414f819170", size = 4301458, upload-time = "2025-03-06T19:54:16.923Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Switch from pre-commit to prek for hook management by updating dependencies, scripts, and configuration.

Enhancements:
- Replace pre-commit CLI with prek for managing hooks
- Add debug-statements and name-tests-test hooks to the pre-commit configuration

Build:
- Update pre-commit dependency in pyproject.toml to use prek instead of pre-commit

Chores:
- Update init.sh to install hooks via prek
- Update pre-commit-check.sh to run hooks via prek
- Regenerate uv.lock with updated dependencies