### PR TITLE
refactor(cli): improve output of `list-models` command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.9.3
+  rev: 0.9.4
   hooks:
       # Update the uv lockfile
   - id: uv-lock

--- a/src/brag/cli.py
+++ b/src/brag/cli.py
@@ -6,7 +6,6 @@ from their GitHub contributions.
 
 import json
 from datetime import datetime
-from itertools import groupby
 from pathlib import Path
 from typing import Annotated, Literal
 
@@ -16,13 +15,14 @@ from github import Github
 from github.Auth import Token
 from loguru import logger
 from rich.console import Console
+from rich.table import Table
 
 from brag import __version__
 from brag.agents import generate_brag_document
 from brag.batching import batch_chunks_by_token_limit
 from brag.models import (
-    CONTEXT_WINDOW_SIZES,
-    REQUIRED_API_KEY_ENV_VARS,
+    KNOWN_CONTEXT_WINDOW_SIZES,
+    KNOWN_REQUIRED_ENV_VARS,
     AvailableModelFullName,
     Model,
     TokenCount,
@@ -636,50 +636,60 @@ def list_models(
         if ":" in model_name:
             provider, name = model_name.split(":", 1)
         else:
-            provider = ""
+            provider = None
             name = model_name
 
-        context_window_size = CONTEXT_WINDOW_SIZES.get(model_name)
-        api_key_env_var = REQUIRED_API_KEY_ENV_VARS.get(provider, "")
+        context_window_size = KNOWN_CONTEXT_WINDOW_SIZES.get(model_name)
+        required_env_vars = KNOWN_REQUIRED_ENV_VARS.get(provider) if provider else None
 
         model_data.append(
             {
                 "provider": provider,
                 "name": name,
                 "full_name": model_name,
-                "api_key_env_var": api_key_env_var,
+                "required_env_vars": required_env_vars,
                 "context_window_size": context_window_size,
             }
         )
 
     match format:
         case "text":
-            # Group by provider
-            grouped_models = groupby(model_data, key=lambda model: model["provider"])
-            for provider, models in grouped_models:
-                models_list = list(models)
-                if provider:
-                    api_key_env_var = REQUIRED_API_KEY_ENV_VARS.get(provider, "")
-                    print(f"{provider}:")
-                    if api_key_env_var:
-                        print(f"  API key environment variable: {api_key_env_var}")
-                    print("  Models:")
-                    for model in models_list:
-                        context_info = (
-                            f" ({model['context_window_size']:,} tokens)"
-                            if model["context_window_size"] is not None
-                            else " (Unknown - use --context-window-size)"
-                        )
-                        print(f"    {model['name']}{context_info}")
+            # Create a Rich table for better formatting
+            console = Console()
+            table = Table(title="Available Models")
+
+            # Add columns
+            table.add_column("Full Name", style="cyan", no_wrap=False)
+            table.add_column("Provider", style="magenta")
+            table.add_column("Name", style="green")
+            table.add_column("Required Env Vars", style="yellow")
+            table.add_column("Context Window Size", style="blue", justify="right")
+
+            # Add rows
+            for model in model_data:
+                # Format required environment variables
+
+                env_vars = model["required_env_vars"]
+                if env_vars is not None:
+                    env_vars_str = ", ".join(env_vars)  # type: ignore
                 else:
-                    print("Other models:")
-                    for model in models_list:
-                        context_info = (
-                            f" ({model['context_window_size']:,} tokens)"
-                            if model["context_window_size"] is not None
-                            else " (Unknown - use --context-window-size)"
-                        )
-                        print(f"    {model['full_name']}{context_info}")
+                    env_vars_str = "?"
+
+                # Format context window size
+                context_size = model["context_window_size"]
+                context_size_str = (
+                    f"{context_size:_}" if context_size is not None else "?"
+                )
+
+                table.add_row(
+                    str(model["full_name"]),
+                    str(model["provider"] or "?"),
+                    str(model["name"]),
+                    env_vars_str,
+                    context_size_str,
+                )
+
+            console.print(table)
         case "json":
             print(json.dumps(model_data, indent=2))
 

--- a/src/brag/models.py
+++ b/src/brag/models.py
@@ -14,19 +14,11 @@ from pydantic_ai.models import KnownModelName as _KnownModelName
 
 # type AvailableModelFullName = _KnownModelName
 type AvailableModelFullName = str
-# type ProviderName = Literal[
-#     "openai",
-#     "anthropic",
-#     "cohere",
-#     "google-gla",
-#     "groq",
-#     "mistral",
-# ]
 type ProviderName = str
 type ModelName = str
 type TokenCount = int
 
-CONTEXT_WINDOW_SIZES: Final[dict[AvailableModelFullName, TokenCount]] = {
+KNOWN_CONTEXT_WINDOW_SIZES: Final[dict[AvailableModelFullName, TokenCount]] = {
     # ==========================================================
     # OpenAI
     # https://platform.openai.com/docs/models
@@ -131,13 +123,13 @@ CONTEXT_WINDOW_SIZES: Final[dict[AvailableModelFullName, TokenCount]] = {
     "mistral:mistral-small-latest": 32_000,
 }
 
-REQUIRED_API_KEY_ENV_VARS: Final[dict[ProviderName, str]] = {
-    "openai": "OPENAI_API_KEY",
-    "anthropic": "ANTHROPIC_API_KEY",
-    "cohere": "COHERE_API_KEY",
-    "google-gla": "GOOGLE_API_KEY",
-    "groq": "GROQ_API_KEY",
-    "mistral": "MISTRAL_API_KEY",
+KNOWN_REQUIRED_ENV_VARS: Final[dict[ProviderName, tuple[str, ...]]] = {
+    "openai": ("OPENAI_API_KEY",),
+    "anthropic": ("ANTHROPIC_API_KEY",),
+    "cohere": ("COHERE_API_KEY",),
+    "google-gla": ("GOOGLE_API_KEY",),
+    "groq": ("GROQ_API_KEY",),
+    "mistral": ("MISTRAL_API_KEY",),
 }
 
 
@@ -176,12 +168,12 @@ class Model(BaseModel):
         Returns:
             The default context window size for the model, or None if not found.
         """
-        return CONTEXT_WINDOW_SIZES.get(self.full_name)
+        return KNOWN_CONTEXT_WINDOW_SIZES.get(self.full_name)
 
 
 def iter_pydantic_ai_model_full_names() -> Iterator[AvailableModelFullName]:
     """Iterate over all available models from pydantic-ai's known models."""
-    yield from get_literal_type_args(_KnownModelName)
+    yield from get_literal_type_args(_KnownModelName.__value__)
 
 
 if __name__ == "__main__":
@@ -192,4 +184,7 @@ if __name__ == "__main__":
     pprint(sorted(iter_pydantic_ai_model_full_names()))
     print()
     print("Models with known context window sizes:")
-    pprint(sorted(CONTEXT_WINDOW_SIZES.keys()))
+    pprint(KNOWN_CONTEXT_WINDOW_SIZES)
+    print()
+    print("Models with known required environment variables:")
+    pprint(KNOWN_REQUIRED_ENV_VARS)


### PR DESCRIPTION
## Summary by Sourcery

Refactor the `list-models` command to present model data in a formatted Rich table, rename and centralize context window size and required environment variable constants for consistency, and bump the pre-commit hook version.

Enhancements:
- Display available models in a Rich table with columns for full name, provider, model name, required env vars, and context window size
- Rename CONTEXT_WINDOW_SIZES to KNOWN_CONTEXT_WINDOW_SIZES and REQUIRED_API_KEY_ENV_VARS to KNOWN_REQUIRED_ENV_VARS with tuple values
- Treat provider as optional (None) instead of empty string and update related lookups
- Adjust iter_pydantic_ai_model_full_names and get_default_context_window_size to use the renamed constants

Build:
- Update uv-pre-commit hook revision from 0.9.3 to 0.9.4