### PR TITLE
fix(cli): validate that the commit count is larger than 0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.9.3
+  rev: 0.9.4
   hooks:
       # Update the uv lockfile
   - id: uv-lock

--- a/src/brag/cli.py
+++ b/src/brag/cli.py
@@ -271,6 +271,9 @@ async def from_repo(  # noqa: PLR0912 # Ignore this for now - we need to refacto
 
         commits_count = len(github_commits)
 
+        if not commits_count:
+            raise ValueError("No commits found for the given repository and date range")
+
         logger.info(
             "Processing {commits} for {author} in {repo}",
             commits=(
@@ -539,6 +542,9 @@ async def from_local(
         git_commits = git_commits.limit(limit)
 
     commits_count = len(git_commits)
+
+    if not commits_count:
+        raise ValueError("No commits found for the given repository and date range")
 
     logger.info(
         "Processing {commits} for {author} in {repo}",


### PR DESCRIPTION
## Summary by Sourcery

Validate that the commit count is greater than zero in CLI operations and bump the uv-pre-commit hook version

Bug Fixes:
- Add checks in from_repo and from_local to raise an error when no commits are found

Build:
- Update uv-pre-commit hook version from 0.9.3 to 0.9.4